### PR TITLE
Add inventoried item type

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2408,6 +2408,12 @@
       "type": "string",
       "title": "Agent ID"
     },
+    "itemtype": {
+      "type": "string",
+      "title": "Item type",
+      "default": "Computer",
+      "pattern": "^(Computer|Phone|NetworkEquipment|Printer)$"
+    },
     "query": {
       "type": "string",
       "default": "INVENTORY",


### PR DESCRIPTION
The goal is to identify what kind of hardware is inventoried (mainly Computer until now, but could be usefull for serval else that could use the same format, such as Phone).