### PR TITLE
Property update for new protocol

### DIFF
--- a/examples/computer_1.json
+++ b/examples/computer_1.json
@@ -821,5 +821,5 @@
         ]
     },
     "deviceid": "glpixps-2018-07-09-09-07-13",
-    "query": "INVENTORY"
+    "action": "inventory"
 }

--- a/examples/computer_1_partial_batteries.json
+++ b/examples/computer_1_partial_batteries.json
@@ -40,6 +40,6 @@
         "versionclient": "FusionInventory-Agent_v2.5.2-1.fc31"
     },
     "deviceid": "glpixps-2018-07-09-09-07-13",
-    "query": "INVENTORY",
+    "action": "inventory",
     "partial": true
 }

--- a/examples/computer_1_partial_cpu.json
+++ b/examples/computer_1_partial_cpu.json
@@ -45,6 +45,6 @@
         "versionclient": "FusionInventory-Agent_v2.5.2-1.fc31"
     },
     "deviceid": "glpixps-2018-07-09-09-07-13",
-    "query": "INVENTORY",
+    "action": "inventory",
     "partial": true
 }

--- a/examples/computer_1_partial_memory.json
+++ b/examples/computer_1_partial_memory.json
@@ -52,6 +52,6 @@
         "versionclient": "FusionInventory-Agent_v2.5.2-1.fc31"
     },
     "deviceid": "glpixps-2018-07-09-09-07-13",
-    "query": "INVENTORY",
+    "action": "inventory",
     "partial": true
 }

--- a/examples/computer_1_partial_softs.json
+++ b/examples/computer_1_partial_softs.json
@@ -112,6 +112,6 @@
         "versionclient": "FusionInventory-Agent_v2.5.2-1.fc31"
     },
     "deviceid": "glpixps-2018-07-09-09-07-13",
-    "query": "INVENTORY",
+    "action": "inventory",
     "partial": true
 }

--- a/examples/computer_1_partial_volumes.json
+++ b/examples/computer_1_partial_volumes.json
@@ -87,6 +87,6 @@
         "versionclient": "FusionInventory-Agent_v2.5.2-1.fc31"
     },
     "deviceid": "glpixps-2018-07-09-09-07-13",
-    "query": "INVENTORY",
+    "action": "inventory",
     "partial": true
 }

--- a/examples/computer_2.json
+++ b/examples/computer_2.json
@@ -73,6 +73,6 @@
         ]
     },
     "deviceid": "acomputer-2021-01-26-14-32-36",
-    "query": "INVENTORY",
+    "action": "inventory",
     "itemtype": "Computer"
 }

--- a/examples/computer_2_partial_dbs.json
+++ b/examples/computer_2_partial_dbs.json
@@ -63,7 +63,7 @@
         ]
     },
     "deviceid": "acomputer-2021-01-26-14-32-36",
-    "query": "INVENTORY",
+    "action": "inventory",
     "itemtype": "Computer",
     "partial": true
 }

--- a/examples/computer_2_partial_vms.json
+++ b/examples/computer_2_partial_vms.json
@@ -73,7 +73,7 @@
         ]
     },
     "deviceid": "acomputer-2021-01-26-14-32-36",
-    "query": "INVENTORY",
+    "action": "inventory",
     "itemtype": "Computer",
     "partial": true
 }

--- a/examples/computer_3.json
+++ b/examples/computer_3.json
@@ -30977,6 +30977,6 @@
         ]
     },
     "deviceid": "LF014-2017-02-20-12-19-56",
-    "query": "INVENTORY",
+    "action": "inventory",
     "itemtype": "Computer"
 }

--- a/examples/computer_3_updated.json
+++ b/examples/computer_3_updated.json
@@ -35710,6 +35710,6 @@
         ]
     },
     "deviceid": "LF014-2017-02-20-12-19-56",
-    "query": "INVENTORY",
+    "action": "inventory",
     "itemtype": "Computer"
 }

--- a/examples/networkequipment_1.json
+++ b/examples/networkequipment_1.json
@@ -5011,6 +5011,6 @@
         ]
     },
     "deviceid": "foo",
-    "query": "SNMP",
+    "action": "netinventory",
     "itemtype": "NetworkEquipment"
 }

--- a/examples/networkequipment_2.json
+++ b/examples/networkequipment_2.json
@@ -13690,6 +13690,6 @@
         ]
     },
     "deviceid": "3k-1-pa3.glpi-project.infra-2020-12-31-11-28-51",
-    "query": "SNMP",
+    "action": "netinventory",
     "itemtype": "NetworkEquipment"
 }

--- a/examples/networkequipment_3.json
+++ b/examples/networkequipment_3.json
@@ -1745,6 +1745,6 @@
         ]
     },
     "deviceid": "HP-2530-48G-2020-12-31-11-28-51",
-    "query": "SNMP",
+    "action": "netinventory",
     "itemtype": "NetworkEquipment"
 }

--- a/examples/networkequipment_4.json
+++ b/examples/networkequipment_4.json
@@ -3457,6 +3457,6 @@
         ]
     },
     "deviceid": "CH-GV1-DSI-WLC-INSID-1-2020-12-31-11-28-51",
-    "query": "SNMP",
+    "action": "netinventory",
     "itemtype": "NetworkEquipment"
 }

--- a/examples/networkequipment_5.json
+++ b/examples/networkequipment_5.json
@@ -2102,6 +2102,6 @@
         ]
     },
     "deviceid": "DGS-3420-52T-2020-12-31-11-28-51",
-    "query": "SNMP",
+    "action": "netinventory",
     "itemtype": "NetworkEquipment"
 }

--- a/examples/phone_1.json
+++ b/examples/phone_1.json
@@ -1,5 +1,5 @@
 {
-    "query": "INVENTORY",
+    "action": "inventory",
     "deviceid": "Mi9TPro-T\u00e9l\u00e9phoneM-2019-12-18-14-30-16",
     "content": {
         "versionclient": "example-app-java",

--- a/examples/printer_1.json
+++ b/examples/printer_1.json
@@ -71,7 +71,7 @@
         ],
         "versionclient": "missing"
     },
-    "query": "SNMP",
+    "action": "netinventory",
     "deviceid": "NPIF2BE10-2020-12-31-11-28-51",
     "itemtype": "Printer"
 }

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2971,7 +2971,7 @@
     "action": {
       "type": "string",
       "default": "inventory",
-      "pattern": "^(injector|inventory|netdiscovery|netinventory)$"
+      "pattern": "^(injector|inventory|netdiscovery|netinventory|.*)$"
     }
   },
   "additionalProperties": false

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2971,7 +2971,7 @@
     "action": {
       "type": "string",
       "default": "inventory",
-      "pattern": "^(inventory|netdiscovery|netinventory)$"
+      "pattern": "^(injector|inventory|netdiscovery|netinventory)$"
     }
   },
   "additionalProperties": false

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2968,10 +2968,10 @@
       "title": "Is inventory partial?",
       "default": false
     },
-    "query": {
+    "action": {
       "type": "string",
-      "default": "INVENTORY",
-      "pattern": "^(INVENTORY|SNMP)$"
+      "default": "inventory",
+      "pattern": "^(inventory|netdiscovery|netinventory)$"
     }
   },
   "additionalProperties": false

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -247,6 +247,24 @@ class Converter
     {
         //all keys are now lowercase
         $data = $this->arrayChangeKeyCaseRecursive($data);
+
+        if (!isset($data['action'])) {
+            $query = $data['query'] ?? ($this->isNetworkInventory($datz) ? null : 'inventory');
+
+            switch ($query) {
+                case 'SNMP':
+                case 'SNMPQUERY':
+                case null:
+                    $data['action'] = 'netinventory';
+                    break;
+                case 'INVENTORY':
+                default:
+                    $data['action'] = 'inventory';
+                    break;
+            }
+        }
+        unset($data['query']);
+
         $data = $this->convertNetworkInventory($data);
 
         //replace bad typed values...
@@ -1115,7 +1133,7 @@ class Converter
      */
     public function convertNetworkInventory(array $data): array
     {
-        if (!isset($data['content']['device'])) {
+        if (!$this->isNetworkInventory($data)) {
             //not a network inventory XML
             return $data;
         }
@@ -1130,10 +1148,6 @@ class Converter
         }
 
         $device = $data['content']['device'];
-
-        if (!isset($data['query']) || $data['query'] == 'SNMPQUERY') {
-            $data['query'] = 'SNMP';
-        }
 
         foreach ($device as $key => $device_data) {
             switch ($key) {
@@ -1350,5 +1364,10 @@ class Converter
 
             unset($data['pciid']);
         }
+    }
+
+    private function isNetworkInventory($data): bool
+    {
+        return isset($data['content']['device']);
     }
 }

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -249,15 +249,14 @@ class Converter
         $data = $this->arrayChangeKeyCaseRecursive($data);
 
         if (!isset($data['action'])) {
-            $query = $data['query'] ?? ($this->isNetworkInventory($datz) ? null : 'inventory');
+            $query = $data['query'] ?? ($this->isNetworkInventory($data) ? 'snmp' : 'inventory');
 
-            switch ($query) {
-                case 'SNMP':
-                case 'SNMPQUERY':
-                case null:
+            switch (strtolower($query)) {
+                case 'snmp':
+                case 'snmpquery':
                     $data['action'] = 'netinventory';
                     break;
-                case 'INVENTORY':
+                case 'inventory':
                 default:
                     $data['action'] = 'inventory';
                     break;

--- a/tests/Glpi/Inventory/tests/units/Converter.php
+++ b/tests/Glpi/Inventory/tests/units/Converter.php
@@ -448,7 +448,7 @@ class Converter extends \atoum {
 
         $this->object($json = json_decode($json_str));
         $this->string($json->deviceid)->isIdenticalTo('foo');
-        $this->string($json->query)->isIdenticalTo('SNMP');
+        $this->string($json->action)->isIdenticalTo('netinventory');
         $this->string($json->itemtype)->isIdenticalTo('NetworkEquipment');
 
         $device = $json->content->network_device;
@@ -482,7 +482,7 @@ class Converter extends \atoum {
 
         $this->object($json = json_decode($json_str));
         $this->string($json->deviceid)->isIdenticalTo('foo');
-        $this->string($json->query)->isIdenticalTo('SNMP');
+        $this->string($json->action)->isIdenticalTo('netinventory');
         $this->string($json->itemtype)->isIdenticalTo('NetworkEquipment');
 
         $device = $json->content->network_device;
@@ -523,7 +523,7 @@ class Converter extends \atoum {
 
         $this->object($json = json_decode($json_str));
         $this->string($json->deviceid)->isIdenticalTo('foo');
-        $this->string($json->query)->isIdenticalTo('SNMP');
+        $this->string($json->action)->isIdenticalTo('netinventory');
         $this->string($json->itemtype)->isIdenticalTo('NetworkEquipment');
 
         $device = $json->content->network_device;
@@ -561,7 +561,7 @@ class Converter extends \atoum {
 
         $this->object($json = json_decode($json_str));
         $this->string($json->deviceid)->isIdenticalTo('foo');
-        $this->string($json->query)->isIdenticalTo('SNMP');
+        $this->string($json->action)->isIdenticalTo('netinventory');
         $this->string($json->itemtype)->isIdenticalTo('NetworkEquipment');
 
         $device = $json->content->network_device;


### PR DESCRIPTION
This would be more protocol friendly and will identify the source task kind.

The `action` property would mean what action the client was doing.

Anyway the purpose of the `content` is still identified by the `itemtype` property.

The converter should be updated accordingly.