### PR TITLE
Feature/cleanup

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -623,12 +623,6 @@
                 "3"
               ]
             },
-            "ipaddr": {
-              "type": "string",
-              "examples": [
-                "192.168.1.103/192.168.124.1/192.168.11.96"
-              ]
-            },
             "lastloggeduser": {
               "type": "string",
               "examples": [

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -615,14 +615,6 @@
                 "172.28.200.20/172.21.201.241/192.168.1.1"
               ]
             },
-            "etime": {
-              "type": "integer",
-              "title": "Time (seconds) needed to run the inventory",
-              "default": "",
-              "examples": [
-                "3"
-              ]
-            },
             "lastloggeduser": {
               "type": "string",
               "examples": [
@@ -2647,6 +2639,14 @@
               "type": "string",
               "examples": [
                 "/usr/bin/fusioninventory-agent"
+              ]
+            },
+            "etime": {
+              "type": "integer",
+              "title": "Time (seconds) needed to run the inventory",
+              "default": "",
+              "examples": [
+                "3"
               ]
             },
             "version": {


### PR DESCRIPTION
* remove ipaddr from hardware section as not used
* move etime from hardware to versionprovider as it is only used for manual debugging and could make the hardware section not compatible for a future partial inventory support