### PR TITLE
feat: remove unused property

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -710,9 +710,6 @@
             },
             "winlang": {
               "type": "string"
-            },
-            "vmname": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -713,9 +713,6 @@
             },
             "vmname": {
               "type": "string"
-            },
-            "vmhostserial": {
-              "type": "string"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
VMHOSTSERIAL & VMNAME appears to be an attempt to support AIX LPAR containers to host linking back to 2013 in FusionInventory Agent.
I didn't find any reference to these properties in GLPI or even in FusionInventory plugin (even in its git history) so I decided to remove them from GLPI Agent.