### PR TITLE
Support property for secure boot being enabled

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -248,8 +248,9 @@
             "enclosureserial": {
               "type": "string"
             },
-            "secure_boot_enabled": {
-              "type": "boolean"
+            "secure_boot": {
+              "type": "string",
+              "pattern": "^(enabled|disabled|unsupported)$"
             }
           },
           "additionalProperties": false

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -247,6 +247,9 @@
             },
             "enclosureserial": {
               "type": "string"
+            },
+            "secure_boot_enabled": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Seems like good information to be able to track in GLPI for security reasons. Also, if Windows 11 requires this to be set still at release, it helps technicians get an idea of which computers are compatible and which need it enabled still.

I don't know how easy it will be for other agents, but it can be implemented by the Jamf plugin since Jamf already has this information for Mac computers. Macs actually report a secure boot level, but like a lot of other things, this seems unique to Macs only and it only describes how OS integrity is verified.
https://support.apple.com/en-us/HT208198

I don't know the best way to display this information in GLPI yet. It could go in Firmware but I don't know if specific properties of a Computer BIOS should go there.