### PR TITLE
vmtype regex update

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2063,7 +2063,7 @@
                 "examples": [
                   "libvirt"
                 ],
-                "pattern": "^(physical|xen|virtualbox|virtual machine|vmware|qemu|solariszone|vserver|openvz|bsdjail|parallels|hyperv|aix_lpar|docker|libvirt|lxd|lxc|virtuozzo)$"
+                "pattern": "^(physical|xen|virtualbox|virtual machine|vmware|qemu|solaris ?zones?|vserver|openvz|bsdjail|parallels|hyperv|aix_lpar|docker|libvirt|lxd|lxc|virtuozzo|kvm|hpvm|wsl[12])$"
               },
               "mac": {
                 "type": "string"


### PR DESCRIPTION
kvm, hpvm, wsl1 & wsl2 was missing
glpi-agent reports 'Solaris Zones' in place of 'solariszone'