### PR TITLE
Add printer missing page counters

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2593,6 +2593,21 @@
             },
             "copyblack": {
               "type": "integer"
+            },
+            "copyblack_a3": {
+              "type": "integer"
+            },
+            "copycolor": {
+              "type": "integer"
+            },
+            "copycolor_a3": {
+              "type": "integer"
+            },
+            "faxtotal": {
+              "type": "integer"
+            },
+            "duplex": {
+              "type": "integer"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
We missed few printer page counters that GLPI-Agent or FusionInventory agent can set on printer asset while doing netinventory task.