### PR TITLE
Hardware should be placed in content

### DIFF
--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1461,7 +1461,7 @@ class Converter
                     unset($device[$key]);
                     break;
                 case 'workgroup':
-                    $data['hardware']['workgroup'] = $device[$key];
+                    $data['content']['hardware']['workgroup'] = $device[$key];
                     unset($device[$key]);
                     break;
                 case 'authsnmp':


### PR DESCRIPTION
This fixes an issue identified in [NetInventory task not supported by server #68](https://github.com/glpi-project/glpi-agent/issues/68).

XML is refused when importing such netdiscovery XML as WORKGROUP is inserted in the wrong place in the JSON:
```
<?xml version="1.0" encoding="UTF-8" ?>
<REQUEST>
  <CONTENT>
    <DEVICE>
      <AUTHPORT />  <AUTHPROTOCOL />  <AUTHSNMP>1</AUTHSNMP>
      <DESCRIPTION>HP ETHERNET MULTI-ENVIRONMENT,SN:PHBLL4R318,FN:3W91MXR,SVCID:28175,PID:HP LaserJet MFP M426dw</DESCRIPTION>
      <DNSHOSTNAME>192.168.244.9</DNSHOSTNAME>
      <IP>192.168.244.9</IP>
      <IPS>
        <IP>192.168.244.9</IP>
      </IPS>
      <MAC>b4:b6:86:79:b0:f9</MAC>
      <MANUFACTURER>Hewlett-Packard</MANUFACTURER>
      <MODEL>HP LaserJet MFP M426dw</MODEL>
      <NETBIOSNAME>NPI79B0F9</NETBIOSNAME>
      <SERIAL>PHBLL4R318</SERIAL>
      <SNMPHOSTNAME>NPI79B0F9</SNMPHOSTNAME>
      <TYPE>PRINTER</TYPE>
      <UPTIME>5 days, 21:04:45.71</UPTIME>
      <WORKGROUP>WORKGROUP</WORKGROUP>
    </DEVICE>
    <MODULEVERSION>5.0</MODULEVERSION>
    <PROCESSNUMBER>1</PROCESSNUMBER>
  </CONTENT>
  <DEVICEID>foo</DEVICEID>
  <QUERY>NETDISCOVERY</QUERY>
</REQUEST>
```