### PR TITLE
Manage other networks status

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -1233,7 +1233,7 @@
                 "examples": [
                   "Down"
                 ],
-                "pattern": "^(up|down)$"
+                "pattern": "^(up|down|dormant|notpresent|lowerlayerdown|unknown|testing)$"
               },
               "type": {
                 "type": "string",

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -1231,7 +1231,8 @@
               "status": {
                 "type": "string",
                 "examples": [
-                  "Down"
+                  "down",
+                  "dormant"
                 ],
                 "pattern": "^(up|down|dormant|notpresent|lowerlayerdown|unknown|testing)$"
               },


### PR DESCRIPTION
Add new status for ```ǸETWORKS``` nodes

https://datatracker.ietf.org/doc/html/rfc2863#section-3.1.12
https://raspberry-projects.com/pi/pi-operating-systems/raspbian/network-settings/networking-commands

> What:		/sys/class/net/<iface>/operstate
> Description:
> 		Indicates the interface RFC2863 operational state as a string.
> 
> 		Possible values are:
> 
> 		"unknown", "notpresent", "down", "lowerlayerdown", "testing",
> 		"dormant", "up".