### PR TITLE
Exclude files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.github/       export-ignore
+/tests/         export-ignore
+/.atoum.php     export-ignore
+/.gitattributes export-ignore
+/.gitignore     export-ignore


### PR DESCRIPTION
Using export-ignore git attribute would permit to make the dist package ligther (see https://php.watch/articles/composer-gitattributes#export-ignore).
