### PR TITLE
Remove pattern on storage interface property

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -1852,8 +1852,7 @@
                 "type": "string",
                 "examples": [
                   "IDE"
-                ],
-                "pattern": "^(SCSI|HDC|IDE|USB|1394|SATA|SAS|ATAPI)$"
+                ]
               },
               "manufacturer": {
                 "type": "string",


### PR DESCRIPTION
It makes really no sens to be such restrictive on storage interface. On glpi-project/glpi-agent#207, the user can't import a NVMe storage. I can't image how many storage interfaces we are just missing with the current pattern and I don't think expanding the pattern is a solution.

Closes glpi-project/glpi-agent#207