### PR TITLE
bugfix: netport['aggregate']['port'] may be a string

### DIFF
--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1438,7 +1438,8 @@ class Converter
                                 [$netport['connections']['connection']];
                         }
                         if (isset($netport['aggregate'])) {
-                            $netport['aggregate'] = is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port']) ?
+                            $netport['aggregate'] =
+                              is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port']) ?
                                 $netport['aggregate']['port'] :
                                 [$netport['aggregate']['port']];
                             $netport['aggregate'] = array_map('intval', $netport['aggregate']);

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1441,7 +1441,7 @@ class Converter
                             if (!is_array($netport['aggregate']['port'])) {
                                 $netport['aggregate']['port'] = [$netport['aggregate']['port']];
                             }
-                            $netport['aggregate'] = array_is_list($netport['aggregate']['port']) ?
+                            $netport['aggregate'] = is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port']) ?
                                 $netport['aggregate']['port'] :
                                 [$netport['aggregate']['port']];
                             $netport['aggregate'] = array_map('intval', $netport['aggregate']);

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1438,7 +1438,8 @@ class Converter
                                 [$netport['connections']['connection']];
                         }
                         if (isset($netport['aggregate'])) {
-                            $netport['aggregate'] = is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port'])
+                            $netport['aggregate'] = is_array($netport['aggregate']['port'])
+                                && array_is_list($netport['aggregate']['port'])
                                 ? $netport['aggregate']['port']
                                 : [$netport['aggregate']['port']];
                             $netport['aggregate'] = array_map('intval', $netport['aggregate']);

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1438,10 +1438,9 @@ class Converter
                                 [$netport['connections']['connection']];
                         }
                         if (isset($netport['aggregate'])) {
-                            $netport['aggregate'] =
-                              is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port']) ?
-                                $netport['aggregate']['port'] :
-                                [$netport['aggregate']['port']];
+                            $netport['aggregate'] = is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port'])
+                                ? $netport['aggregate']['port']
+                                : [$netport['aggregate']['port']];
                             $netport['aggregate'] = array_map('intval', $netport['aggregate']);
                         }
 

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1438,6 +1438,9 @@ class Converter
                                 [$netport['connections']['connection']];
                         }
                         if (isset($netport['aggregate'])) {
+                            if (!is_array($netport['aggregate']['port'])) {
+                                $netport['aggregate']['port'] = [$netport['aggregate']['port']];
+                            }
                             $netport['aggregate'] = array_is_list($netport['aggregate']['port']) ?
                                 $netport['aggregate']['port'] :
                                 [$netport['aggregate']['port']];

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1438,9 +1438,6 @@ class Converter
                                 [$netport['connections']['connection']];
                         }
                         if (isset($netport['aggregate'])) {
-                            if (!is_array($netport['aggregate']['port'])) {
-                                $netport['aggregate']['port'] = [$netport['aggregate']['port']];
-                            }
                             $netport['aggregate'] = is_array($netport['aggregate']['port']) && array_is_list($netport['aggregate']['port']) ?
                                 $netport['aggregate']['port'] :
                                 [$netport['aggregate']['port']];

--- a/tests/data/15.xml
+++ b/tests/data/15.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<REQUEST>
+  <CONTENT>
+    <DEVICE>
+      <FIRMWARES>
+        <DESCRIPTION>device firmware</DESCRIPTION>
+        <MANUFACTURER>Juniper</MANUFACTURER>
+        <NAME>EX6210</NAME>
+        <TYPE>device</TYPE>
+        <VERSION>12.3R3.4</VERSION>
+      </FIRMWARES>
+      <PORTS>
+        <PORT>
+          <AGGREGATE>
+            <PORT>1092</PORT>
+          </AGGREGATE>
+          <IFALIAS>sw-ex8208-tmk</IFALIAS>
+          <IFDESCR>ae27</IFDESCR>
+          <IFINERRORS>0</IFINERRORS>
+          <IFINOCTETS>2843220484</IFINOCTETS>
+          <IFINTERNALSTATUS>1</IFINTERNALSTATUS>
+          <IFLASTCHANGE>0:00:09.45</IFLASTCHANGE>
+          <IFMTU>1514</IFMTU>
+          <IFNAME>ae27</IFNAME>
+          <IFNUMBER>1317</IFNUMBER>
+          <IFOUTERRORS>0</IFOUTERRORS>
+          <IFOUTOCTETS>3178610497</IFOUTOCTETS>
+          <IFSPEED>20000000000</IFSPEED>
+          <IFSTATUS>1</IFSTATUS>
+          <IFTYPE>161</IFTYPE>
+          <MAC>88:e0:f3:b0:68:1e</MAC>
+        </PORT>
+      </PORTS>
+    </DEVICE>
+    <MODULEVERSION>4.1</MODULEVERSION>
+    <PROCESSNUMBER>1</PROCESSNUMBER>
+  </CONTENT>
+  <DEVICEID>foo</DEVICEID>
+  <QUERY>SNMPQUERY</QUERY>
+</REQUEST>


### PR DESCRIPTION
The following source
```
        <PORT>
          <AGGREGATE>
            <PORT>624</PORT>
          </AGGREGATE>
```
will make `$netport['aggregate']['port']` a string and fire an exception:
```
*** Uncaught Exception TypeError: array_is_list(): Argument #1 ($array) must be of type array, string given, called in vendor/glpi-project/inventory_format/lib/php/Converter.php on line 1443 in vendor/symfony/polyfill-php81/bootstrap.php at line 23
```