### PR TITLE
feat(schema): handle Unmanaged asset

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2845,7 +2845,7 @@
             },
             "type": {
               "type": "string",
-              "pattern": "^(Computer|Networking|Printer|Storage|Power|Phone|Video|KVM)$"
+              "pattern": "^(Unmanaged|Computer|Networking|Printer|Storage|Power|Phone|Video|KVM)$"
             },
             "uptime": {
               "type": "string",
@@ -2976,8 +2976,8 @@
     "itemtype": {
       "type": "string",
       "title": "Item type",
-      "default": "Computer",
-      "pattern": "^(Computer|Phone|NetworkEquipment|Printer)$"
+      "default": "Unmanaged",
+      "pattern": "^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$"
     },
     "partial": {
       "type": "boolean",

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2976,7 +2976,7 @@
     "itemtype": {
       "type": "string",
       "title": "Item type",
-      "default": "Computer",
+      "default": "Unmanaged",
       "pattern": "^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$"
     },
     "partial": {

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2976,7 +2976,7 @@
     "itemtype": {
       "type": "string",
       "title": "Item type",
-      "default": "Unmanaged",
+      "default": "Computer",
       "pattern": "^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$"
     },
     "partial": {

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1384,6 +1384,7 @@ class Converter
                                 case 'Computer':
                                 case 'Phone':
                                 case 'Printer':
+                                case 'Unmanaged':
                                     $itemtype = $device_info['type'];
                                     break;
                                 case 'Networking':
@@ -1538,7 +1539,7 @@ class Converter
 
         $device = &$data['content']['device'];
         if (!isset($device['info'])) {
-            $device['info'] = ['type' => 'Computer'];
+            $device['info'] = ['type' => 'Unmanaged'];
         }
         $device_info = &$data['content']['device']['info'];
 

--- a/tests/Glpi/Inventory/tests/units/Converter.php
+++ b/tests/Glpi/Inventory/tests/units/Converter.php
@@ -646,8 +646,8 @@ class Converter extends \atoum {
         $this->string($json->action)->isIdenticalTo('netdiscovery');
         $device = $json->content->network_device;
         $this->string($device->name)->isIdenticalTo('homeassistant');
-        $this->string($device->type)->isIdenticalTo('Computer');
-        $this->string($json->itemtype)->isIdenticalTo('Computer');
+        $this->string($device->type)->isIdenticalTo('Unmanaged');
+        $this->string($json->itemtype)->isIdenticalTo('Unmanaged');
 
         //example from old specs documentation
         $this->string($xml_path = realpath(TU_DIR . '/data/10.xml'));


### PR DESCRIPTION
Handle ```Unmanaged``` asset

Rather than to use ```Computer``` as default ```itemtype```
If agent can't get ```itemtype``` set it as ```unmanaged``` 

usefull for https://github.com/glpi-project/glpi/pull/13326

need : https://github.com/glpi-project/inventory_format/pull/85