### PR TITLE
fix(ci): update source

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: XML well formed
         run: |
+          sudo apt update
           sudo apt-get install expat
           xmlwf tests/data/*.xml
 


### PR DESCRIPTION
Try to fix ```CI``` error

```

Run sudo apt-get install expat
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  expat
0 upgraded, 1 newly installed, 0 to remove and 100 not upgraded.
Need to get 15.6 kB of archives.
After this operation, 73.7 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 expat amd64 2.2.9-1ubuntu0.4
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 expat amd64 2.2.9-1ubuntu0.4
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/e/expat/expat_2.2.9-1ubuntu0.4_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```