### PR TITLE
Automatically update source files

### DIFF
--- a/.github/workflows/refresh-sources.yml
+++ b/.github/workflows/refresh-sources.yml
@@ -2,7 +2,7 @@ name: "Refresh sources"
 
 on:
   schedule:
-    - cron: "0 1,15 * * *"
+    - cron: "0 0 1,15 * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/refresh-sources.yml
+++ b/.github/workflows/refresh-sources.yml
@@ -1,0 +1,48 @@
+name: "Refresh sources"
+
+on:
+  schedule:
+    - cron: "0 1,15 * * *"
+  workflow_dispatch:
+
+jobs:
+  refresh-sources:
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Refresh sources"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+      - name: "Refresh sources"
+        id: "refresh"
+        run: |
+          composer install --ansi --no-dev --no-interaction --no-progress --prefer-dist
+          bin/refresh_hw_sources
+          bin/build_hw_jsons
+          if [ ! -z "$(git status --porcelain)" ]; then
+            BRANCH="task/refresh-sources-$(date +'%Y%m%d%H%M%S')"
+            git config --local user.email "bot@glpi-project.org"
+            git config --local user.name "GLPI Project bot"
+            git checkout -b $BRANCH
+            git add .
+            git commit -m "Refresh source files"
+            git push origin $BRANCH
+            echo "create_pr=yes" >> $GITHUB_OUTPUT
+            echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          fi
+      - name: "Create pull request"
+        if: ${{ steps.refresh.outputs.create_pr == 'yes' }}
+        uses: "actions/github-script@v6"
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'Refresh source files',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: '${{ steps.refresh.outputs.branch }}',
+              base: '${{ github.ref_name }}',
+              body: 'Automatic refresh of source files'
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 -!/data/README.md
 -/tests/code-coverage/
 -/vendor/
+/composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-vendor/
-tests/code-coverage/
-data/*.json
-data/*.txt
-data/*.ids
+-/data/*
+-!/data/README.md
+-/tests/code-coverage/
+-/vendor/

--- a/bin/refresh_hw_sources
+++ b/bin/refresh_hw_sources
@@ -4,5 +4,4 @@
 require_once 'vendor/autoload.php';
 
 $tojson = new Glpi\Inventory\FilesToJSON;
-$tojson->cleanFiles();
-$tojson->downloadSources();
+$tojson->refreshSources();

--- a/data/README.md
+++ b/data/README.md
@@ -4,7 +4,7 @@ Hardware database mapping for:
 - Network equipments
 
 Original files can be updated from a Linux system.
-Just copy the files from /usr/share/hwdata/
+Just copy the files from /usr/share/hwdata/ to source_files directory.
 
 Then, generate JSON files running FilesToJSON.php script.
 It is automatically done running composer.

--- a/lib/php/FilesToJSON.php
+++ b/lib/php/FilesToJSON.php
@@ -188,7 +188,7 @@ class FilesToJSON
                 $uri = 'http://www.linux-usb.org/usb.ids';
                 break;
             case self::TYPE_OUI:
-                $uri = 'http://standards-oui.ieee.org/oui/oui.txt';
+                $uri = 'https://standards-oui.ieee.org/oui/oui.txt';
                 break;
             case self::TYPE_IFTYPE:
                 $uri = 'https://www.iana.org/assignments/smi-numbers/smi-numbers-5.csv';


### PR DESCRIPTION
A long time ago, we were not able to find why curl was failing to fetch OUI source file. I checked again and figure out that problem was usage of `http` instead of `https`.

Now that fetching source files with curl is possible, I refactored a bit the code to separate source files refresh and conversion to JSON, in order to add a workflow that will try to update source files every 15 days and will create a PR when someething has been updated.

Here is a manual run of the workflow https://github.com/cedric-anne/glpi-project-inventory_format/actions/runs/4491105282/jobs/7899091269 and corresponding PR https://github.com/cedric-anne/glpi-project-inventory_format/pull/2 .

This should permit to keep source files up-to-date (they are 2 years old now).