### PR TITLE
Fix OUI file fetching

### DIFF
--- a/lib/php/FilesToJSON.php
+++ b/lib/php/FilesToJSON.php
@@ -188,7 +188,7 @@ class FilesToJSON
                 $uri = 'http://www.linux-usb.org/usb.ids';
                 break;
             case self::TYPE_OUI:
-                $uri = 'http://standards-oui.ieee.org/oui/oui.txt';
+                $uri = 'https://standards-oui.ieee.org/oui/oui.txt';
                 break;
             case self::TYPE_IFTYPE:
                 $uri = 'https://www.iana.org/assignments/smi-numbers/smi-numbers-5.csv';
@@ -350,7 +350,8 @@ class FilesToJSON
         $opts = [
             CURLOPT_URL             => $url,
             CURLOPT_USERAGENT       => "GLPI/Inventory format 1.0",
-            CURLOPT_RETURNTRANSFER  => 1,
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_FOLLOWLOCATION  => true,
         ] + $eopts;
 
         curl_setopt_array($ch, $opts);


### PR DESCRIPTION
`curl` call to OUI source file was failing because request was redirected from `http` to `https`.

1. I fixed the source file URL.
2. I added the `CURLOPT_FOLLOWLOCATION` option to handle potential future redirects.