### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    versioning-strategy: "increase"


### PR DESCRIPTION
I figured out that there are warning on CI jobs about usage outdated version of actions.
![image](https://user-images.githubusercontent.com/33253653/228352705-91216ddb-142e-4ab2-b6d8-dd2abe25c453.png)

`dependabot` can help to maintain versions up-to-date (for Github Actions, but also for PHP dependencies).