### PR TITLE
Fix master branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Current version is 1.1.x. Using a less specific alias would permit to keep it working until we change main version to 2.x.