### PR TITLE
Prevent autoload file to be included from `cwd`

### DIFF
--- a/bin/build_hw_jsons
+++ b/bin/build_hw_jsons
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require_once 'vendor/autoload.php';
+if (file_exists($autoload = __DIR__ . '/../vendor/autoload.php')) {
+    // Rely on self autoload (usefull for devs)
+    require_once $autoload;
+} else {
+    // Rely on parent project autoload
+    require_once __DIR__ . '/../../../autoload.php';
+}
+
 
 $tojson = new Glpi\Inventory\FilesToJSON();
 $tojson->run();

--- a/bin/convert
+++ b/bin/convert
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require_once 'vendor/autoload.php';
+if (file_exists($autoload = __DIR__ . '/../vendor/autoload.php')) {
+    // Rely on self autoload (usefull for devs)
+    require_once $autoload;
+} else {
+    // Rely on parent project autoload
+    require_once __DIR__ . '/../../../autoload.php';
+}
+
 require_once __DIR__ . '/../lib/php/Converter.php';
 
 

--- a/bin/refresh_hw_sources
+++ b/bin/refresh_hw_sources
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require_once 'vendor/autoload.php';
+if (file_exists($autoload = __DIR__ . '/../vendor/autoload.php')) {
+    // Rely on self autoload (usefull for devs)
+    require_once $autoload;
+} else {
+    // Rely on parent project autoload
+    require_once __DIR__ . '/../../../autoload.php';
+}
+
 
 $tojson = new Glpi\Inventory\FilesToJSON();
 $tojson->refreshSources();

--- a/bin/validate
+++ b/bin/validate
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require_once 'vendor/autoload.php';
+if (file_exists($autoload = __DIR__ . '/../vendor/autoload.php')) {
+    // Rely on self autoload (usefull for devs)
+    require_once $autoload;
+} else {
+    // Rely on parent project autoload
+    require_once __DIR__ . '/../../../autoload.php';
+}
+
 require_once 'lib/php/Converter.php';
 
 


### PR DESCRIPTION
I just faced an issue due to the fact that autoload file inclusion is based on a relative path (`require_once 'vendor/autoload.php';`). 

In GLPI build script, the `cwd` is not changed, and we call commands using `$WORKING_DIR/vendor/bin/refresh_hw_sources`. The main purpose of not changing `cwd` is to ensure that user will not have its `cwd` changed when script fails (it is an annoying behaviour).

Problem with inclusion based on relative file is that the path resolution includes the `cwd`. In my case, I was launching the script from `/path/to/glpi/source`, so the `refresh_hw_sources` was loading class files from `/path/to/glpi/source/vendor/glpi-project/inventory_format/lib/` instead of `/tmp/glpi-10.0.7/glpi/vendor/glpi-project/inventory_format/lib/`, and result was that downloaded source files were written in my source directory instead of being written in the build working directory.

Using absolute path when including autoload file could prevent such issues.