### PR TITLE
feat(inventory): handle several IPV4 or IPV6

### DIFF
--- a/examples/computer_with_several_ipv4.json
+++ b/examples/computer_with_several_ipv4.json
@@ -1,0 +1,1074 @@
+{
+    "content": {
+        "versionclient": "SCCM-v2.4.1",
+        "accesslog": {
+            "logdate": "2023-05-15 02:23:05",
+            "userid": "xxxxxxx"
+        },
+        "hardware": {
+            "name": "PCVANALITICA",
+            "lastloggeduser": "xxxxxxx",
+            "uuid": "47FA051E-17D7-49D7-A3FF-D393B9FA97EB",
+            "workgroup": "ds.ga.local"
+        },
+        "operatingsystem": {
+            "name": "Microsoft Windows 10 Pro",
+            "full_name": "Microsoft Windows 10 Pro",
+            "arch": "x64-based PC",
+            "version": "10.0.18362"
+        },
+        "bios": {
+            "smodel": "System Product Name",
+            "mmanufacturer": "System manufacturer",
+            "smanufacturer": "System manufacturer",
+            "ssn": "T2351476",
+            "bdate": "2018-10-09",
+            "bmanufacturer": "American Megatrends Inc.",
+            "bversion": "1404",
+            "skunumber": "ALASKA - 1072009"
+        },
+        "cpus": [
+            {
+                "description": "Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz",
+                "manufacturer": "GenuineIntel",
+                "name": "Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz",
+                "speed": 3600,
+                "core": 4,
+                "thread": 4
+            }
+        ],
+        "softwares": [
+            {
+                "name": "N\/A",
+                "version": "1.01.0000",
+                "publisher": "Intel Corporation",
+                "install_date": "2018-07-16"
+            },
+            {
+                "name": "N\/A",
+                "version": "1.02.0000",
+                "publisher": "Intel Corporation",
+                "install_date": "2018-07-16"
+            },
+            {
+                "name": "7-Zip 18.05 (x64)",
+                "version": "18.05",
+                "publisher": "Igor Pavlov"
+            },
+            {
+                "name": "7-Zip 22.01 (x64 edition)",
+                "version": "22.01.00.0",
+                "publisher": "Igor Pavlov",
+                "install_date": "2023-02-10"
+            },
+            {
+                "name": "Actualizaci\u00f3n de NVIDIA 31.2.0.0",
+                "version": "31.2.0.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "Adobe Acrobat Reader - Espa\u00f1ol",
+                "version": "23.001.20174",
+                "publisher": "Adobe Systems Incorporated",
+                "install_date": "2023-05-10"
+            },
+            {
+                "name": "Adobe Refresh Manager",
+                "version": "1.8.0",
+                "publisher": "Adobe Systems Incorporated",
+                "install_date": "2023-04-12"
+            },
+            {
+                "name": "AMD Catalyst Install Manager",
+                "version": "8.0.916.0",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "AMD Drag and Drop Transcoding",
+                "version": "2.00.0000",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "AMD Wireless Display v3.0",
+                "version": "1.0.0.15",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Catalyst Control Center Graphics Previews Common",
+                "version": "2015.0804.21.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Catalyst Control Center InstallProxy",
+                "version": "2015.1104.1643.30033",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Catalyst Control Center Localization All",
+                "version": "2015.0804.21.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Chinese Standard",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Chinese Traditional",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Czech",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Danish",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Dutch",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help English",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Finnish",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help French",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help German",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Greek",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Hungarian",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Italian",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Japanese",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Korean",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Norwegian",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Polish",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Portuguese",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Russian",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Spanish",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Swedish",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Thai",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "CCC Help Turkish",
+                "version": "2015.0804.0020.41908",
+                "publisher": "Advanced Micro Devices, Inc.",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Configuration Manager Client",
+                "version": "5.00.9096.1000",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-03-01"
+            },
+            {
+                "name": "CrowdStrike Device Control",
+                "version": "6.13.12753.0",
+                "publisher": "CrowdStrike, Inc.",
+                "install_date": "2023-03-10"
+            },
+            {
+                "name": "CrowdStrike Firmware Analysis",
+                "version": "6.14.12866.0",
+                "publisher": "CrowdStrike, Inc.",
+                "install_date": "2023-03-10"
+            },
+            {
+                "name": "CrowdStrike Sensor Platform",
+                "version": "6.18.13213.0",
+                "publisher": "CrowdStrike, Inc.",
+                "install_date": "2023-03-10"
+            },
+            {
+                "name": "CrowdStrike Windows Sensor",
+                "version": "6.18.13213.0",
+                "publisher": "CrowdStrike, Inc."
+            },
+            {
+                "name": "DisplayDriverAnalyzer",
+                "version": "398.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "ffdshow [rev 3154] [2009-12-09]",
+                "version": "1.0",
+                "install_date": "2019-10-04"
+            },
+            {
+                "name": "Foxit Reader",
+                "version": "3.1.4.1125",
+                "publisher": "Foxit Software Company"
+            },
+            {
+                "name": "GDR 5343 para SQL Server 2012 (KB3045321)",
+                "version": "11.2.5343.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "GDR 5388 para SQL Server 2012 (KB3194719)",
+                "version": "11.2.5388.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Google Chrome",
+                "version": "112.0.5615.138",
+                "publisher": "Google LLC",
+                "install_date": "2023-04-25"
+            },
+            {
+                "name": "Google Update Helper",
+                "version": "1.3.34.11",
+                "publisher": "Google LLC",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "HCWebControl",
+                "version": "2.0.0.0",
+                "publisher": "Hangzhou Hikvision Digital Technology Co., Ltd.",
+                "install_date": "2021-06-11"
+            },
+            {
+                "name": "HikCentral Professional Control Client",
+                "version": "1.7.1",
+                "publisher": "Hangzhou Hikvision Digital Technology Co., Ltd."
+            },
+            {
+                "name": "Intel(R) Network Connections 23.4.0.19",
+                "version": "23.4.0.19",
+                "publisher": "Intel",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "Intel(R) Processor Graphics",
+                "version": "10.18.10.4276",
+                "publisher": "Intel Corporation"
+            },
+            {
+                "name": "iVMS-4200(V2.8.1.4_ML)",
+                "version": "2.8.1.4",
+                "publisher": "hikvision",
+                "install_date": "2019-06-27"
+            },
+            {
+                "name": "K-Lite Codec Pack 9.7.0 (Basic)",
+                "version": "9.7.0",
+                "install_date": "2019-10-04"
+            },
+            {
+                "name": "Microsoft .NET Framework 1.1",
+                "version": "1.1.4322",
+                "publisher": "Microsoft",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft .NET Framework 4 Multi-Targeting Pack",
+                "version": "4.0.30319",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft .NET Framework 4.7.2",
+                "version": "4.7.03062",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-17"
+            },
+            {
+                "name": "Microsoft .NET Framework 4.7.2 (ESN)",
+                "version": "4.7.03062",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-17"
+            },
+            {
+                "name": "Microsoft Application Error Reporting",
+                "version": "12.0.6012.5000",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Help Viewer 1.1",
+                "version": "1.1.40219",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Help Viewer 1.1",
+                "version": "1.1.40219",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Policy Platform",
+                "version": "68.1.1010.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-02-10"
+            },
+            {
+                "name": "Microsoft Report Viewer 2012 Runtime",
+                "version": "11.0.2100.60",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Security Client",
+                "version": "4.10.0209.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-17"
+            },
+            {
+                "name": "Microsoft Silverlight",
+                "version": "5.1.50918.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2008 R2 Management Objects",
+                "version": "10.51.2500.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2008 Setup Support Files",
+                "version": "10.1.2731.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2012"
+            },
+            {
+                "name": "Microsoft SQL Server 2012",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft SQL Server 2012 Native Client",
+                "version": "11.2.5388.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2012 Policies",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2012 RsFx Driver",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2012 Setup (English)",
+                "version": "11.2.5388.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2012 Transact-SQL Compiler Service",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft SQL Server 2012 Transact-SQL ScriptDom",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft SQL Server System CLR Types",
+                "version": "10.51.2500.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft System CLR Types for SQL Server 2012",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2005 Redistributable",
+                "version": "8.0.61001",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2008 Redistributable - x64 9.0.30729",
+                "version": "9.0.30729",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2008 Redistributable - x64 9.0.30729.6161",
+                "version": "9.0.30729.6161",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2008 Redistributable - x86 9.0.30729.6161",
+                "version": "9.0.30729.6161",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2010  x64 Redistributable - 10.0.40219",
+                "version": "10.0.40219",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2010  x86 Redistributable - 10.0.40219",
+                "version": "10.0.40219",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2010  x86 Runtime - 10.0.40219",
+                "version": "10.0.40219",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.50727",
+                "version": "11.0.50727.1",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2012 Redistributable (x86) - 11.0.50727",
+                "version": "11.0.50727.1",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2012 x64 Additional Runtime - 11.0.50727",
+                "version": "11.0.50727",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2012 x64 Minimum Runtime - 11.0.50727",
+                "version": "11.0.50727",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2012 x86 Additional Runtime - 11.0.50727",
+                "version": "11.0.50727",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2012 x86 Minimum Runtime - 11.0.50727",
+                "version": "11.0.50727",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.30501",
+                "version": "12.0.30501.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.30501",
+                "version": "12.0.30501.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.21005",
+                "version": "12.0.21005",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.21005",
+                "version": "12.0.21005",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.21005",
+                "version": "12.0.21005",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.21005",
+                "version": "12.0.21005",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-26"
+            },
+            {
+                "name": "Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914",
+                "version": "14.28.29914.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914",
+                "version": "14.28.29914.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X64 Additional Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-02-10"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-02-10"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X86 Additional Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-02-10"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-02-10"
+            },
+            {
+                "name": "Microsoft Visual Studio 2010 Shell (Isolated) - ENU",
+                "version": "10.0.40219",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "Microsoft VSS Writer for SQL Server 2012",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Netskope Client",
+                "version": "99.0.7.1144",
+                "publisher": "Netskope, Inc.",
+                "install_date": "2023-05-04"
+            },
+            {
+                "name": "NVIDIA Ansel",
+                "version": "5.1.453.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Backend",
+                "version": "31.2.0.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Controlador de 3D Vision 398.11",
+                "version": "398.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA Controlador de audio HD 1.3.37.4",
+                "version": "1.3.37.4",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA Controlador de gr\u00e1ficos 398.11",
+                "version": "398.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA Controlador de la controladora 3D Vision 390.41",
+                "version": "390.41",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Display Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA Display Container LS",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA Display Session Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA Display Watchdog Plugin",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA GeForce Experience 3.14.0.139",
+                "version": "3.14.0.139",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Install Application",
+                "version": "2.1002.291.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "NVIDIA LocalSystem Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Message Bus for NvContainer",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA NetworkService Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA NodeJS",
+                "version": "3.14.0.139",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Optimus Update 31.2.0.0",
+                "version": "31.2.0.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Session Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA ShadowPlay 3.14.0.139",
+                "version": "3.14.0.139",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "Nvidia Share",
+                "version": "3.14.0.139",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA SHIELD Streaming",
+                "version": "7.1.0406",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA SHIELD Wireless Controller Driver",
+                "version": "3.14.0.117",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Software del sistema PhysX 9.17.0524",
+                "version": "9.17.0524",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Stereoscopic 3D Driver",
+                "version": "7.17.13.9640",
+                "publisher": "NVIDIA Corporation"
+            },
+            {
+                "name": "NVIDIA Telemetry Client",
+                "version": "9.3.14.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Telemetry Container",
+                "version": "9.3.14.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA TelemetryApi helper for NvContainer",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Update Core",
+                "version": "31.2.0.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA User Container",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Virtual Audio 4.06.0",
+                "version": "4.06.0",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Virtual Host Controller",
+                "version": "2.02.0.5",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "NVIDIA Watchdog Plugin for NvContainer",
+                "version": "1.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2019-10-21"
+            },
+            {
+                "name": "Panel de control de NVIDIA 398.11",
+                "version": "398.11",
+                "publisher": "NVIDIA Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "Realtek High Definition Audio Driver",
+                "version": "6.0.1.7548",
+                "publisher": "Realtek Semiconductor Corp."
+            },
+            {
+                "name": "Service Pack 2 for SQL Server 2012 (KB2958429)",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "SQL Server 2012 Client Tools",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "SQL Server 2012 Common Files",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "SQL Server 2012 Common Files",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "SQL Server 2012 Database Engine Services",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "SQL Server 2012 Database Engine Services",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "SQL Server 2012 Database Engine Shared",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "SQL Server 2012 Management Studio",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "SQL Server 2012 Management Studio",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2019-09-30"
+            },
+            {
+                "name": "SQL Server Browser for SQL Server 2012",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Sql Server Customer Experience Improvement Program",
+                "version": "11.2.5058.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Surveillance Viewer IPC NB version 0.2.6.3",
+                "version": "0.2.6.3",
+                "publisher": "Surveillance Viewer",
+                "install_date": "2019-08-19"
+            },
+            {
+                "name": "Surveillance Viewer IPC UN version 0.2.1.6",
+                "version": "0.2.1.6",
+                "publisher": "Surveillance Viewer",
+                "install_date": "2021-06-24"
+            },
+            {
+                "name": "TeamViewer 14",
+                "version": "14.6.4835",
+                "publisher": "TeamViewer"
+            },
+            {
+                "name": "Visual Studio 2010 Prerequisites - English",
+                "version": "10.0.40219",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2018-07-30"
+            },
+            {
+                "name": "Web Components",
+                "version": "3.0.7.27",
+                "install_date": "2023-01-24"
+            },
+            {
+                "name": "ZDServer",
+                "version": "1.0.1.4",
+                "publisher": "ZTE Corporation",
+                "install_date": "2023-03-31"
+            },
+            {
+                "name": "ZTE MF823 - Modem USB",
+                "version": "1.0.0.1",
+                "publisher": "ZTE",
+                "install_date": "2018-07-31"
+            },
+            {
+                "name": "ZTE Mobile Broadband Device Drivers 1.0.0.30",
+                "publisher": "ZTE",
+                "install_date": "2018-07-31"
+            }
+        ],
+        "memories": [
+            {
+                "capacity": 8192,
+                "caption": "Memoria f\u00edsica",
+                "description": "Memoria f\u00edsica",
+                "formfactor": "8",
+                "speed": "2400",
+                "type": "BANK 3",
+                "numslots": 4,
+                "manufacturer": "075D"
+            }
+        ],
+        "videos": [
+            {
+                "chipset": "GeForce GT 1030",
+                "memory": 2048,
+                "name": "NVIDIA GeForce GT 1030",
+                "resolution": "1280x1024",
+                "pcislot": "1"
+            }
+        ],
+        "sounds": [
+            {
+                "description": "High Definition Audio Device",
+                "manufacturer": "Microsoft",
+                "name": "High Definition Audio Device"
+            },
+            {
+                "description": "NVIDIA High Definition Audio",
+                "manufacturer": "NVIDIA",
+                "name": "NVIDIA High Definition Audio"
+            },
+            {
+                "description": "NVIDIA Virtual Audio Device (Wave Extensible) (WDM)",
+                "manufacturer": "Microsoft",
+                "name": "NVIDIA Virtual Audio Device (Wave Extensible) (WDM)"
+            }
+        ],
+        "users": [
+            {
+                "login": "xxxxxxx"
+            }
+        ],
+        "networks": [
+            {
+                "description": "WAN Miniport (IP)",
+                "mac": "66:A7:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IP)",
+                "mac": "6E:E3:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IP)",
+                "mac": "7E:09:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IPv6)",
+                "mac": "66:A7:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IPv6)",
+                "mac": "6E:E3:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IPv6)",
+                "mac": "7E:09:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (Network Monitor)",
+                "mac": "66:A7:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (Network Monitor)",
+                "mac": "6E:E3:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (Network Monitor)",
+                "mac": "7E:09:20:52:41:53"
+            },
+            {
+                "ipaddress": [
+                    "169.254.41.148",
+                    "192.168.0.225",
+                    "10.50.78.89"
+                ],
+                "ipaddress6": "fe80::c0b2:cf62:cba8:8d8",
+                "description": "Intel(R) Ethernet Connection (7) I219-V",
+                "ipmask": "255.255.255.0, 255.255.255.0, 255.255.255.128, 64",
+                "ipgateway": "10.50.78.19",
+                "mac": "04:92:26:D7:AC:51"
+            }
+        ],
+        "drives": [
+            {
+                "description": "Disco fijo local",
+                "filesystem": "NTFS",
+                "free": 309229568,
+                "label": "WD Blue SN570 500GB",
+                "total": 487755776,
+                "volumn": "C:"
+            }
+        ]
+    },
+    "deviceid": "16823975",
+    "action": "inventory",
+    "tag": "SCCM",
+    "itemtype": "Computer"
+}

--- a/examples/computer_with_several_ipv6.json
+++ b/examples/computer_with_several_ipv6.json
@@ -1,0 +1,437 @@
+{
+    "content": {
+        "versionclient": "SCCM-v2.4.1",
+        "accesslog": {
+            "logdate": "2023-05-15 02:22:53",
+            "userid": "xxxxxxx"
+        },
+        "hardware": {
+            "name": "EMUPC69",
+            "lastloggeduser": "xxxxxxx",
+            "uuid": "B649C417-24A2-48D5-B38B-AA4D7E9257ED",
+            "workgroup": "ds.ga.local"
+        },
+        "operatingsystem": {
+            "name": "Microsoft Windows 10 Enterprise",
+            "full_name": "Microsoft Windows 10 Enterprise",
+            "arch": "x64-based PC",
+            "version": "10.0.19044"
+        },
+        "bios": {
+            "smodel": "HP ProDesk 600 G5 SFF",
+            "mmanufacturer": "HP",
+            "smanufacturer": "HP",
+            "ssn": "CZC946B8WD",
+            "bdate": "2021-04-01",
+            "bmanufacturer": "HP",
+            "bversion": "R07 Ver. 02.08.00",
+            "skunumber": "HPQOEM - 0"
+        },
+        "cpus": [
+            {
+                "description": "Intel(R) Core(TM) i5-9500 CPU @ 3.00GHz",
+                "manufacturer": "GenuineIntel",
+                "name": "Intel(R) Core(TM) i5-9500 CPU @ 3.00GHz",
+                "speed": 3000,
+                "core": 6,
+                "thread": 6
+            }
+        ],
+        "softwares": [
+            {
+                "name": "N\/A",
+                "version": "255.255.65535.0"
+            },
+            {
+                "name": "7-Zip 22.01 (x64 edition)",
+                "version": "22.01.00.0",
+                "publisher": "Igor Pavlov",
+                "install_date": "2022-09-30"
+            },
+            {
+                "name": "ADSelfService Plus Client Software",
+                "version": "5.0.2",
+                "publisher": "ZOHO Corp",
+                "install_date": "2020-03-16"
+            },
+            {
+                "name": "Cisco Jabber",
+                "version": "12.5.2.39445",
+                "publisher": "Cisco Systems, Inc",
+                "install_date": "2020-10-10"
+            },
+            {
+                "name": "Configuration Manager Client",
+                "version": "5.00.9096.1000",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-03-02"
+            },
+            {
+                "name": "CrowdStrike Device Control",
+                "version": "6.35.14960.0",
+                "publisher": "CrowdStrike, Inc.",
+                "install_date": "2023-05-08"
+            },
+            {
+                "name": "CrowdStrike Firmware Analysis",
+                "version": "6.32.14651.0",
+                "publisher": "CrowdStrike, Inc.",
+                "install_date": "2023-05-08"
+            },
+            {
+                "name": "CrowdStrike Sensor Platform",
+                "version": "6.51.16510.0",
+                "publisher": "CrowdStrike, Inc.",
+                "install_date": "2023-05-08"
+            },
+            {
+                "name": "CrowdStrike Windows Sensor",
+                "version": "6.51.16510.0",
+                "publisher": "CrowdStrike, Inc."
+            },
+            {
+                "name": "Dynamic Application Loader Host Interface Service",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "GlobalProtect",
+                "version": "5.2.8",
+                "publisher": "Palo Alto Networks",
+                "install_date": "2021-11-23"
+            },
+            {
+                "name": "Google Chrome",
+                "version": "112.0.5615.138",
+                "publisher": "Google LLC",
+                "install_date": "2021-12-28"
+            },
+            {
+                "name": "HP Connection Optimizer",
+                "version": "2.0.15.0",
+                "publisher": "HP Inc.",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "HP Hotkey Support",
+                "version": "6.2.52.1",
+                "publisher": "HP Inc.",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "HP PC Hardware Diagnostics UEFI",
+                "version": "7.6.0.0",
+                "publisher": "HP",
+                "install_date": "2020-06-11"
+            },
+            {
+                "name": "HP System Default Settings",
+                "version": "1.4.8.2",
+                "publisher": "HP Inc.",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) Chipset Device Software",
+                "version": "10.1.18019.8144",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) Icls",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) LMS",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) Management Engine Components",
+                "version": "1932.12.0.1298",
+                "publisher": "Intel Corporation"
+            },
+            {
+                "name": "Intel(R) Management Engine Components",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) Management Engine Driver",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) OEM Extension",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) Processor Graphics",
+                "version": "26.20.100.7157",
+                "publisher": "Intel Corporation"
+            },
+            {
+                "name": "Intel(R) Wireless Manageability Driver",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Intel(R) Wireless Manageability Driver Extension",
+                "version": "1.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Microsoft Edge",
+                "version": "112.0.1722.46",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-04-21"
+            },
+            {
+                "name": "Microsoft Edge Update",
+                "version": "1.3.175.27"
+            },
+            {
+                "name": "Microsoft Policy Platform",
+                "version": "68.1.1010.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "Microsoft Silverlight",
+                "version": "5.1.50907.0",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-21"
+            },
+            {
+                "name": "Microsoft VC++ redistributables repacked.",
+                "version": "12.0.0.0",
+                "publisher": "Intel Corporation",
+                "install_date": "2019-11-14"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660",
+                "version": "12.0.40660.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40660",
+                "version": "12.0.40660.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40660",
+                "version": "12.0.40660",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40660",
+                "version": "12.0.40660",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40660",
+                "version": "12.0.40660",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40660",
+                "version": "12.0.40660",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914",
+                "version": "14.28.29914.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914",
+                "version": "14.28.29914.0",
+                "publisher": "Microsoft Corporation"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X64 Additional Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2021-09-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2021-09-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X86 Additional Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2021-09-30"
+            },
+            {
+                "name": "Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.28.29914",
+                "version": "14.28.29914",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2021-09-30"
+            },
+            {
+                "name": "Netskope Client",
+                "version": "99.0.7.1144",
+                "publisher": "Netskope, Inc.",
+                "install_date": "2023-05-13"
+            },
+            {
+                "name": "PDFCreator",
+                "version": "3.1.2",
+                "publisher": "pdfforge GmbH",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "Software para dispositivos de chipset Intel\u00ae",
+                "version": "10.1.18019.8144",
+                "publisher": "Intel(R) Corporation"
+            },
+            {
+                "name": "Swivel Taskbar Client",
+                "version": "1.6.6.1",
+                "publisher": "Swivel Secure",
+                "install_date": "2020-03-16"
+            },
+            {
+                "name": "Teams Machine-Wide Installer",
+                "version": "1.3.0.3564",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2020-03-14"
+            },
+            {
+                "name": "WebView2 Runtime de Microsoft Edge",
+                "version": "113.0.1774.42",
+                "publisher": "Microsoft Corporation",
+                "install_date": "2023-05-14"
+            }
+        ],
+        "memories": [
+            {
+                "capacity": 8192,
+                "caption": "Memoria f\u00edsica",
+                "description": "Memoria f\u00edsica",
+                "formfactor": "8",
+                "speed": "2667",
+                "type": "ChannelB",
+                "numslots": 1,
+                "manufacturer": "Hynix\/Hyundai"
+            }
+        ],
+        "videos": [
+            {
+                "chipset": "Intel(R) UHD Graphics Family",
+                "memory": 1024,
+                "name": "Intel(R) UHD Graphics 630",
+                "resolution": "1920x1080",
+                "pcislot": "1"
+            }
+        ],
+        "sounds": [
+            {
+                "description": "Sonido Intel(R) para pantallas",
+                "manufacturer": "Intel(R) Corporation",
+                "name": "Sonido Intel(R) para pantallas"
+            },
+            {
+                "description": "Synaptics HD Audio",
+                "manufacturer": "Synaptics",
+                "name": "Synaptics HD Audio"
+            }
+        ],
+        "users": [
+            {
+                "login": "xxxxxxx"
+            }
+        ],
+        "networks": [
+            {
+                "ipaddress": "192.168.1.133",
+                "ipaddress6": [
+                    "fe80::9bbb:c6ae:3cd5:d9fb",
+                    "2a0c:5a80:140d:4400:c480:da92:e839:ec9d",
+                    "2a0c:5a80:140d:4400:70f7:45d7:71fd:4d85",
+                    "2a0c:5a80:140d:4400:c3a:ccfe:ecdc:42b4",
+                    "2a0c:5a80:140d:4400:89d2:18f3:d43:2dfb"
+                ],
+                "description": "Intel(R) Ethernet Connection (7) I219-LM",
+                "ipmask": "255.255.255.0, 64, 128, 128, 128, 64",
+                "ipdhcp": "192.168.1.1",
+                "ipgateway": "192.168.1.1, fe80::1",
+                "mac": "9C:7B:EF:B3:50:96"
+            },
+            {
+                "ipaddress": "172.27.192.8",
+                "description": "PANGP Virtual Ethernet Adapter #2",
+                "ipmask": "255.255.255.255",
+                "mac": "02:50:41:00:00:01"
+            },
+            {
+                "description": "WAN Miniport (IP)",
+                "mac": "A8:79:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IP)",
+                "mac": "AA:DF:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IP)",
+                "mac": "AC:32:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IPv6)",
+                "mac": "A8:79:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IPv6)",
+                "mac": "AA:DF:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (IPv6)",
+                "mac": "AC:32:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (Network Monitor)",
+                "mac": "A8:79:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (Network Monitor)",
+                "mac": "AA:DF:20:52:41:53"
+            },
+            {
+                "description": "WAN Miniport (Network Monitor)",
+                "mac": "AC:32:20:52:41:53"
+            }
+        ],
+        "drives": [
+            {
+                "description": "Disco fijo local",
+                "filesystem": "NTFS",
+                "free": 169840640,
+                "label": "KBG30ZMV256G KIOXIA",
+                "letter": "Windows",
+                "total": 249083904,
+                "volumn": "C:"
+            }
+        ]
+    },
+    "deviceid": "16811420",
+    "action": "inventory",
+    "tag": "SCCM",
+    "itemtype": "Computer"
+}

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -1180,14 +1180,21 @@
                 "title": "Wether it is a remote management interface such as HP iLO, Sun SC, HP MP"
               },
               "ipaddress": {
-                "type": "string",
-                "examples": [
-                  "127.0.0.1"
-                ],
+                "type": ["string", "array"],
+                "items": {
+                  "type": "string",
+                  "examples": [
+                    "127.0.0.1"
+                  ],
+                  "format": "ipv4"
+                },
                 "format": "ipv4"
               },
               "ipaddress6": {
-                "type": "string"
+                "type": ["string", "array"],
+                "items": {
+                  "type": "string"
+                }
               },
               "ipdhcp": {
                 "type": "string",

--- a/tests/Glpi/Inventory/tests/units/Converter.php
+++ b/tests/Glpi/Inventory/tests/units/Converter.php
@@ -845,4 +845,74 @@ ARM Bios Ver 7.59u v46 454MHz B987-M995-F80-O0,0 MAC:00042d076b88"
         );
         $this->assertCount(1, $json->content->network_ports);
     }
+
+    public function testSeveralIPV4()
+    {
+        $xml_path = realpath(TU_DIR . '/data/18.xml');
+        $this->assertNotEmpty($xml_path);
+
+        $xml = file_get_contents($xml_path);
+        $instance = new \Glpi\Inventory\Converter();
+        $json_str = $instance->convert($xml);
+        $this->assertNotEmpty($json_str);
+
+        $json = json_decode($json_str);
+        $this->assertIsObject($json);
+        $this->assertSame('16823975', $json->deviceid);
+        $this->assertSame('inventory', $json->action);
+        $this->assertSame('Computer', $json->itemtype);
+
+        $ips = $json->content->networks[9];
+        $this->assertSame(
+            [
+                "ipaddress" => [
+                    "169.254.41.148",
+                    "192.168.0.225",
+                    "10.50.78.89",
+                ],
+                "ipaddress6" => "fe80::c0b2:cf62:cba8:8d8",
+                "description" => "Intel(R) Ethernet Connection (7) I219-V",
+                "ipmask" => "255.255.255.0, 255.255.255.0, 255.255.255.128, 64",
+                "ipgateway" => "10.50.78.19",
+                "mac" => "04:92:26:D7:AC:51",
+            ],
+            (array)$ips
+        );
+    }
+
+    public function testSeveralIPV6()
+    {
+        $xml_path = realpath(TU_DIR . '/data/19.xml');
+        $this->assertNotEmpty($xml_path);
+
+        $xml = file_get_contents($xml_path);
+        $instance = new \Glpi\Inventory\Converter();
+        $json_str = $instance->convert($xml);
+        $this->assertNotEmpty($json_str);
+
+        $json = json_decode($json_str);
+        $this->assertIsObject($json);
+        $this->assertSame('16811420', $json->deviceid);
+        $this->assertSame('inventory', $json->action);
+        $this->assertSame('Computer', $json->itemtype);
+        $ips = $json->content->networks[0];
+        $this->assertSame(
+            [
+                "ipaddress" => "192.168.1.133",
+                "ipaddress6" => [
+                    "fe80::9bbb:c6ae:3cd5:d9fb",
+                    "2a0c:5a80:140d:4400:c480:da92:e839:ec9d",
+                    "2a0c:5a80:140d:4400:70f7:45d7:71fd:4d85",
+                    "2a0c:5a80:140d:4400:c3a:ccfe:ecdc:42b4",
+                    "2a0c:5a80:140d:4400:89d2:18f3:d43:2dfb",
+                ],
+                "description" => "Intel(R) Ethernet Connection (7) I219-LM",
+                "ipmask" => "255.255.255.0, 64, 128, 128, 128, 64",
+                "ipdhcp" => "192.168.1.1",
+                "ipgateway" => "192.168.1.1, fe80::1",
+                "mac" => "9C:7B:EF:B3:50:96",
+            ],
+            (array)$ips
+        );
+    }
 }

--- a/tests/data/18.xml
+++ b/tests/data/18.xml
@@ -1,0 +1,1099 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<REQUEST>
+   <CONTENT>
+      <VERSIONCLIENT>SCCM-v2.4.1</VERSIONCLIENT>
+      <ACCESSLOG>
+         <LOGDATE>2023-05-15 02:23:05</LOGDATE>
+         <USERID>xxxxxxx</USERID>
+      </ACCESSLOG>
+      <ACCOUNTINFO>
+         <KEYNAME>TAG</KEYNAME>
+         <KEYVALUE>SCCM</KEYVALUE>
+      </ACCOUNTINFO>
+      <HARDWARE>
+         <NAME>PCVANALITICA</NAME>
+         <LASTLOGGEDUSER>xxxxxxx</LASTLOGGEDUSER>
+         <UUID>47FA051E-17D7-49D7-A3FF-D393B9FA97EB</UUID>
+         <USERID>xxxxxxx</USERID>
+         <WORKGROUP>ds.ga.local</WORKGROUP>
+         <OSNAME>Microsoft Windows 10 Pro</OSNAME>
+         <OSCOMMENTS/>
+         <OSVERSION>10.0.18362</OSVERSION>
+      </HARDWARE>
+      <OPERATINGSYSTEM>
+         <NAME>Microsoft Windows 10 Pro</NAME>
+         <FULL_NAME>Microsoft Windows 10 Pro</FULL_NAME>
+         <ARCH>x64-based PC</ARCH>
+         <VERSION>10.0.18362</VERSION>
+         <SERVICE_PACK/>
+      </OPERATINGSYSTEM>
+      <BIOS>
+         <SMODEL>System Product Name</SMODEL>
+         <TYPE>Workstation</TYPE>
+         <MMANUFACTURER>System manufacturer</MMANUFACTURER>
+         <SMANUFACTURER>System manufacturer</SMANUFACTURER>
+         <SSN>T2351476</SSN>
+         <BDATE>09/10/2018</BDATE>
+         <BMANUFACTURER>American Megatrends Inc.</BMANUFACTURER>
+         <BVERSION>1404</BVERSION>
+         <SKUNUMBER>ALASKA - 1072009</SKUNUMBER>
+      </BIOS>
+      <CPUS>
+         <DESCRIPTION>Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz</DESCRIPTION>
+         <MANUFACTURER>GenuineIntel</MANUFACTURER>
+         <NAME>Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz</NAME>
+         <SPEED>3600</SPEED>
+         <TYPE>64</TYPE>
+         <CORE>4</CORE>
+         <THREAD>4</THREAD>
+      </CPUS>
+      <SOFTWARES>
+         <NAME><![CDATA[N/A]]></NAME>
+         <VERSION>1.01.0000</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>16/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[N/A]]></NAME>
+         <VERSION>1.02.0000</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>16/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[7-Zip 18.05 (x64)]]></NAME>
+         <VERSION>18.05</VERSION>
+         <PUBLISHER>Igor Pavlov</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[7-Zip 22.01 (x64 edition)]]></NAME>
+         <VERSION>22.01.00.0</VERSION>
+         <PUBLISHER>Igor Pavlov</PUBLISHER>
+         <INSTALLDATE>10/02/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Actualización de NVIDIA 31.2.0.0]]></NAME>
+         <VERSION>31.2.0.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Adobe Acrobat Reader - Español]]></NAME>
+         <VERSION>23.001.20174</VERSION>
+         <PUBLISHER>Adobe Systems Incorporated</PUBLISHER>
+         <INSTALLDATE>10/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Adobe Refresh Manager]]></NAME>
+         <VERSION>1.8.0</VERSION>
+         <PUBLISHER>Adobe Systems Incorporated</PUBLISHER>
+         <INSTALLDATE>12/04/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[AMD Catalyst Install Manager]]></NAME>
+         <VERSION>8.0.916.0</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[AMD Drag and Drop Transcoding]]></NAME>
+         <VERSION>2.00.0000</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[AMD Wireless Display v3.0]]></NAME>
+         <VERSION>1.0.0.15</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Catalyst Control Center Graphics Previews Common]]></NAME>
+         <VERSION>2015.0804.21.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Catalyst Control Center InstallProxy]]></NAME>
+         <VERSION>2015.1104.1643.30033</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Catalyst Control Center Localization All]]></NAME>
+         <VERSION>2015.0804.21.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Chinese Standard]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Chinese Traditional]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Czech]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Danish]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Dutch]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help English]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Finnish]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help French]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help German]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Greek]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Hungarian]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Italian]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Japanese]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Korean]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Norwegian]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Polish]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Portuguese]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Russian]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Spanish]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Swedish]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Thai]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CCC Help Turkish]]></NAME>
+         <VERSION>2015.0804.0020.41908</VERSION>
+         <PUBLISHER>Advanced Micro Devices, Inc.</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Configuration Manager Client]]></NAME>
+         <VERSION>5.00.9096.1000</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>01/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Device Control]]></NAME>
+         <VERSION>6.13.12753.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+         <INSTALLDATE>10/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Firmware Analysis]]></NAME>
+         <VERSION>6.14.12866.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+         <INSTALLDATE>10/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Sensor Platform]]></NAME>
+         <VERSION>6.18.13213.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+         <INSTALLDATE>10/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Windows Sensor]]></NAME>
+         <VERSION>6.18.13213.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[DisplayDriverAnalyzer]]></NAME>
+         <VERSION>398.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[ffdshow [rev 3154] [2009-12-09]]]></NAME>
+         <VERSION>1.0</VERSION>
+         <INSTALLDATE>04/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Foxit Reader]]></NAME>
+         <VERSION>3.1.4.1125</VERSION>
+         <PUBLISHER>Foxit Software Company</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[GDR 5343 para SQL Server 2012 (KB3045321)]]></NAME>
+         <VERSION>11.2.5343.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[GDR 5388 para SQL Server 2012 (KB3194719)]]></NAME>
+         <VERSION>11.2.5388.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Google Chrome]]></NAME>
+         <VERSION>112.0.5615.138</VERSION>
+         <PUBLISHER>Google LLC</PUBLISHER>
+         <INSTALLDATE>25/04/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Google Update Helper]]></NAME>
+         <VERSION>1.3.34.11</VERSION>
+         <PUBLISHER>Google LLC</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[HCWebControl]]></NAME>
+         <VERSION>2.0.0.0</VERSION>
+         <PUBLISHER>Hangzhou Hikvision Digital Technology Co., Ltd.</PUBLISHER>
+         <INSTALLDATE>11/06/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[HikCentral Professional Control Client]]></NAME>
+         <VERSION>1.7.1</VERSION>
+         <PUBLISHER>Hangzhou Hikvision Digital Technology Co., Ltd.</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Network Connections 23.4.0.19]]></NAME>
+         <VERSION>23.4.0.19</VERSION>
+         <PUBLISHER>Intel</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Processor Graphics]]></NAME>
+         <VERSION>10.18.10.4276</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[iVMS-4200(V2.8.1.4_ML)]]></NAME>
+         <VERSION>2.8.1.4</VERSION>
+         <PUBLISHER>hikvision</PUBLISHER>
+         <INSTALLDATE>27/06/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[K-Lite Codec Pack 9.7.0 (Basic)]]></NAME>
+         <VERSION>9.7.0</VERSION>
+         <INSTALLDATE>04/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft .NET Framework 1.1]]></NAME>
+         <VERSION>1.1.4322</VERSION>
+         <PUBLISHER>Microsoft</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft .NET Framework 4 Multi-Targeting Pack]]></NAME>
+         <VERSION>4.0.30319</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft .NET Framework 4.7.2]]></NAME>
+         <VERSION>4.7.03062</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>17/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft .NET Framework 4.7.2 (ESN)]]></NAME>
+         <VERSION>4.7.03062</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>17/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Application Error Reporting]]></NAME>
+         <VERSION>12.0.6012.5000</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Help Viewer 1.1]]></NAME>
+         <VERSION>1.1.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Help Viewer 1.1]]></NAME>
+         <VERSION>1.1.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Policy Platform]]></NAME>
+         <VERSION>68.1.1010.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>10/02/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Report Viewer 2012 Runtime]]></NAME>
+         <VERSION>11.0.2100.60</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Security Client]]></NAME>
+         <VERSION>4.10.0209.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>17/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Silverlight]]></NAME>
+         <VERSION>5.1.50918.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2008 R2 Management Objects]]></NAME>
+         <VERSION>10.51.2500.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2008 Setup Support Files]]></NAME>
+         <VERSION>10.1.2731.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012]]></NAME>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012]]></NAME>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012 Native Client]]></NAME>
+         <VERSION>11.2.5388.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012 Policies]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012 RsFx Driver]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012 Setup (English)]]></NAME>
+         <VERSION>11.2.5388.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012 Transact-SQL Compiler Service]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server 2012 Transact-SQL ScriptDom]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft SQL Server System CLR Types]]></NAME>
+         <VERSION>10.51.2500.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft System CLR Types for SQL Server 2012]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2005 Redistributable]]></NAME>
+         <VERSION>8.0.61001</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2008 Redistributable - x64 9.0.30729]]></NAME>
+         <VERSION>9.0.30729</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2008 Redistributable - x64 9.0.30729.6161]]></NAME>
+         <VERSION>9.0.30729.6161</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2008 Redistributable - x86 9.0.30729.6161]]></NAME>
+         <VERSION>9.0.30729.6161</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2010  x64 Redistributable - 10.0.40219]]></NAME>
+         <VERSION>10.0.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2010  x86 Redistributable - 10.0.40219]]></NAME>
+         <VERSION>10.0.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2010  x86 Runtime - 10.0.40219]]></NAME>
+         <VERSION>10.0.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.50727]]></NAME>
+         <VERSION>11.0.50727.1</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2012 Redistributable (x86) - 11.0.50727]]></NAME>
+         <VERSION>11.0.50727.1</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2012 x64 Additional Runtime - 11.0.50727]]></NAME>
+         <VERSION>11.0.50727</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2012 x64 Minimum Runtime - 11.0.50727]]></NAME>
+         <VERSION>11.0.50727</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2012 x86 Additional Runtime - 11.0.50727]]></NAME>
+         <VERSION>11.0.50727</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2012 x86 Minimum Runtime - 11.0.50727]]></NAME>
+         <VERSION>11.0.50727</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.30501]]></NAME>
+         <VERSION>12.0.30501.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.30501]]></NAME>
+         <VERSION>12.0.30501.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.21005]]></NAME>
+         <VERSION>12.0.21005</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.21005]]></NAME>
+         <VERSION>12.0.21005</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.21005]]></NAME>
+         <VERSION>12.0.21005</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.21005]]></NAME>
+         <VERSION>12.0.21005</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>26/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X64 Additional Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>10/02/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>10/02/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X86 Additional Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>10/02/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>10/02/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual Studio 2010 Shell (Isolated) - ENU]]></NAME>
+         <VERSION>10.0.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft VSS Writer for SQL Server 2012]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Netskope Client]]></NAME>
+         <VERSION>99.0.7.1144</VERSION>
+         <PUBLISHER>Netskope, Inc.</PUBLISHER>
+         <INSTALLDATE>04/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Ansel]]></NAME>
+         <VERSION>5.1.453.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Backend]]></NAME>
+         <VERSION>31.2.0.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Controlador de 3D Vision 398.11]]></NAME>
+         <VERSION>398.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Controlador de audio HD 1.3.37.4]]></NAME>
+         <VERSION>1.3.37.4</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Controlador de gráficos 398.11]]></NAME>
+         <VERSION>398.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Controlador de la controladora 3D Vision 390.41]]></NAME>
+         <VERSION>390.41</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Display Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Display Container LS]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Display Session Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Display Watchdog Plugin]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA GeForce Experience 3.14.0.139]]></NAME>
+         <VERSION>3.14.0.139</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Install Application]]></NAME>
+         <VERSION>2.1002.291.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA LocalSystem Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Message Bus for NvContainer]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA NetworkService Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA NodeJS]]></NAME>
+         <VERSION>3.14.0.139</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Optimus Update 31.2.0.0]]></NAME>
+         <VERSION>31.2.0.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Session Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA ShadowPlay 3.14.0.139]]></NAME>
+         <VERSION>3.14.0.139</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Nvidia Share]]></NAME>
+         <VERSION>3.14.0.139</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA SHIELD Streaming]]></NAME>
+         <VERSION>7.1.0406</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA SHIELD Wireless Controller Driver]]></NAME>
+         <VERSION>3.14.0.117</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Software del sistema PhysX 9.17.0524]]></NAME>
+         <VERSION>9.17.0524</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Stereoscopic 3D Driver]]></NAME>
+         <VERSION>7.17.13.9640</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Telemetry Client]]></NAME>
+         <VERSION>9.3.14.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Telemetry Container]]></NAME>
+         <VERSION>9.3.14.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA TelemetryApi helper for NvContainer]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Update Core]]></NAME>
+         <VERSION>31.2.0.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA User Container]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Virtual Audio 4.06.0]]></NAME>
+         <VERSION>4.06.0</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Virtual Host Controller]]></NAME>
+         <VERSION>2.02.0.5</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[NVIDIA Watchdog Plugin for NvContainer]]></NAME>
+         <VERSION>1.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>21/10/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Panel de control de NVIDIA 398.11]]></NAME>
+         <VERSION>398.11</VERSION>
+         <PUBLISHER>NVIDIA Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Realtek High Definition Audio Driver]]></NAME>
+         <VERSION>6.0.1.7548</VERSION>
+         <PUBLISHER>Realtek Semiconductor Corp.</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Service Pack 2 for SQL Server 2012 (KB2958429)]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Client Tools]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Common Files]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Common Files]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Database Engine Services]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Database Engine Services]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Database Engine Shared]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Management Studio]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server 2012 Management Studio]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[SQL Server Browser for SQL Server 2012]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Sql Server Customer Experience Improvement Program]]></NAME>
+         <VERSION>11.2.5058.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Surveillance Viewer IPC NB version 0.2.6.3]]></NAME>
+         <VERSION>0.2.6.3</VERSION>
+         <PUBLISHER>Surveillance Viewer</PUBLISHER>
+         <INSTALLDATE>19/08/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Surveillance Viewer IPC UN version 0.2.1.6]]></NAME>
+         <VERSION>0.2.1.6</VERSION>
+         <PUBLISHER>Surveillance Viewer</PUBLISHER>
+         <INSTALLDATE>24/06/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[TeamViewer 14]]></NAME>
+         <VERSION>14.6.4835</VERSION>
+         <PUBLISHER>TeamViewer</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Visual Studio 2010 Prerequisites - English]]></NAME>
+         <VERSION>10.0.40219</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Web Components]]></NAME>
+         <VERSION>3.0.7.27</VERSION>
+         <INSTALLDATE>24/01/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[ZDServer]]></NAME>
+         <VERSION>1.0.1.4</VERSION>
+         <PUBLISHER>ZTE Corporation</PUBLISHER>
+         <INSTALLDATE>31/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[ZTE MF823 - Modem USB]]></NAME>
+         <VERSION>1.0.0.1</VERSION>
+         <PUBLISHER>ZTE</PUBLISHER>
+         <INSTALLDATE>31/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[ZTE Mobile Broadband Device Drivers 1.0.0.30]]></NAME>
+         <PUBLISHER>ZTE</PUBLISHER>
+         <INSTALLDATE>31/07/2018</INSTALLDATE>
+      </SOFTWARES>
+      <MEMORIES>
+         <CAPACITY>8192</CAPACITY>
+         <CAPTION>Memoria física</CAPTION>
+         <DESCRIPTION>Memoria física</DESCRIPTION>
+         <FORMFACTOR>8</FORMFACTOR>
+         <REMOVABLE/>
+         <PURPOSE/>
+         <SPEED>2400</SPEED>
+         <TYPE>BANK 3</TYPE>
+         <NUMSLOTS>4</NUMSLOTS>
+         <SERIALNUMBER/>
+         <MANUFACTURER>075D</MANUFACTURER>
+      </MEMORIES>
+      <VIDEOS>
+         <CHIPSET>GeForce GT 1030</CHIPSET>
+         <MEMORY>2048</MEMORY>
+         <NAME>NVIDIA GeForce GT 1030</NAME>
+         <RESOLUTION>1280x1024</RESOLUTION>
+         <PCISLOT>1</PCISLOT>
+      </VIDEOS>
+      <SOUNDS>
+         <DESCRIPTION>High Definition Audio Device</DESCRIPTION>
+         <MANUFACTURER>Microsoft</MANUFACTURER>
+         <NAME>High Definition Audio Device</NAME>
+      </SOUNDS>
+      <SOUNDS>
+         <DESCRIPTION>NVIDIA High Definition Audio</DESCRIPTION>
+         <MANUFACTURER>NVIDIA</MANUFACTURER>
+         <NAME>NVIDIA High Definition Audio</NAME>
+      </SOUNDS>
+      <SOUNDS>
+         <DESCRIPTION>NVIDIA Virtual Audio Device (Wave Extensible) (WDM)</DESCRIPTION>
+         <MANUFACTURER>Microsoft</MANUFACTURER>
+         <NAME>NVIDIA Virtual Audio Device (Wave Extensible) (WDM)</NAME>
+      </SOUNDS>
+      <USERS>
+         <LOGIN>xxxxxxx</LOGIN>
+      </USERS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IP)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>66:A7:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IP)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>6E:E3:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IP)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>7E:09:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IPv6)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>66:A7:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IPv6)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>6E:E3:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IPv6)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>7E:09:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (Network Monitor)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>66:A7:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (Network Monitor)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>6E:E3:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (Network Monitor)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>7E:09:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <IPADDRESS>169.254.41.148</IPADDRESS>
+         <IPADDRESS>192.168.0.225</IPADDRESS>
+         <IPADDRESS>10.50.78.89</IPADDRESS>
+         <IPADDRESS6>fe80::c0b2:cf62:cba8:8d8</IPADDRESS6>
+         <DESCRIPTION>Intel(R) Ethernet Connection (7) I219-V</DESCRIPTION>
+         <IPMASK>255.255.255.0, 255.255.255.0, 255.255.255.128, 64</IPMASK>
+         <IPDHCP/>
+         <IPGATEWAY>10.50.78.19</IPGATEWAY>
+         <MACADDR>04:92:26:D7:AC:51</MACADDR>
+      </NETWORKS>
+      <DRIVES>
+         <DESCRIPTION>Disco fijo local</DESCRIPTION>
+         <FILESYSTEM>NTFS</FILESYSTEM>
+         <FREE>309229568</FREE>
+         <LABEL>WD Blue SN570 500GB</LABEL>
+         <LETTER/>
+         <TOTAL>487755776</TOTAL>
+         <VOLUMN>C:</VOLUMN>
+      </DRIVES>
+   </CONTENT>
+   <DEVICEID>16823975</DEVICEID>
+   <QUERY>INVENTORY</QUERY>
+   <PROLOG/>
+</REQUEST>

--- a/tests/data/19.xml
+++ b/tests/data/19.xml
@@ -1,0 +1,462 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<REQUEST>
+   <CONTENT>
+      <VERSIONCLIENT>SCCM-v2.4.1</VERSIONCLIENT>
+      <ACCESSLOG>
+         <LOGDATE>2023-05-15 02:22:53</LOGDATE>
+         <USERID>xxxxxxx</USERID>
+      </ACCESSLOG>
+      <ACCOUNTINFO>
+         <KEYNAME>TAG</KEYNAME>
+         <KEYVALUE>SCCM</KEYVALUE>
+      </ACCOUNTINFO>
+      <HARDWARE>
+         <NAME>EMUPC69</NAME>
+         <LASTLOGGEDUSER>xxxxxxx</LASTLOGGEDUSER>
+         <UUID>B649C417-24A2-48D5-B38B-AA4D7E9257ED</UUID>
+         <USERID>xxxxxxx</USERID>
+         <WORKGROUP>ds.ga.local</WORKGROUP>
+         <OSNAME>Microsoft Windows 10 Enterprise</OSNAME>
+         <OSCOMMENTS/>
+         <OSVERSION>10.0.19044</OSVERSION>
+      </HARDWARE>
+      <OPERATINGSYSTEM>
+         <NAME>Microsoft Windows 10 Enterprise</NAME>
+         <FULL_NAME>Microsoft Windows 10 Enterprise</FULL_NAME>
+         <ARCH>x64-based PC</ARCH>
+         <VERSION>10.0.19044</VERSION>
+         <SERVICE_PACK/>
+      </OPERATINGSYSTEM>
+      <BIOS>
+         <SMODEL>HP ProDesk 600 G5 SFF</SMODEL>
+         <TYPE>Workstation</TYPE>
+         <MMANUFACTURER>HP</MMANUFACTURER>
+         <SMANUFACTURER>HP</SMANUFACTURER>
+         <SSN>CZC946B8WD</SSN>
+         <BDATE>01/04/2021</BDATE>
+         <BMANUFACTURER>HP</BMANUFACTURER>
+         <BVERSION>R07 Ver. 02.08.00</BVERSION>
+         <SKUNUMBER>HPQOEM - 0</SKUNUMBER>
+      </BIOS>
+      <CPUS>
+         <DESCRIPTION>Intel(R) Core(TM) i5-9500 CPU @ 3.00GHz</DESCRIPTION>
+         <MANUFACTURER>GenuineIntel</MANUFACTURER>
+         <NAME>Intel(R) Core(TM) i5-9500 CPU @ 3.00GHz</NAME>
+         <SPEED>3000</SPEED>
+         <TYPE>64</TYPE>
+         <CORE>6</CORE>
+         <THREAD>6</THREAD>
+      </CPUS>
+      <SOFTWARES>
+         <NAME><![CDATA[N/A]]></NAME>
+         <VERSION>255.255.65535.0</VERSION>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[7-Zip 22.01 (x64 edition)]]></NAME>
+         <VERSION>22.01.00.0</VERSION>
+         <PUBLISHER>Igor Pavlov</PUBLISHER>
+         <INSTALLDATE>30/09/2022</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[ADSelfService Plus Client Software]]></NAME>
+         <VERSION>5.0.2</VERSION>
+         <PUBLISHER>ZOHO Corp</PUBLISHER>
+         <INSTALLDATE>16/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Cisco Jabber]]></NAME>
+         <VERSION>12.5.2.39445</VERSION>
+         <PUBLISHER>Cisco Systems, Inc</PUBLISHER>
+         <INSTALLDATE>10/10/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Configuration Manager Client]]></NAME>
+         <VERSION>5.00.9096.1000</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>02/03/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Device Control]]></NAME>
+         <VERSION>6.35.14960.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+         <INSTALLDATE>08/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Firmware Analysis]]></NAME>
+         <VERSION>6.32.14651.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+         <INSTALLDATE>08/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Sensor Platform]]></NAME>
+         <VERSION>6.51.16510.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+         <INSTALLDATE>08/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[CrowdStrike Windows Sensor]]></NAME>
+         <VERSION>6.51.16510.0</VERSION>
+         <PUBLISHER>CrowdStrike, Inc.</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Dynamic Application Loader Host Interface Service]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[GlobalProtect]]></NAME>
+         <VERSION>5.2.8</VERSION>
+         <PUBLISHER>Palo Alto Networks</PUBLISHER>
+         <INSTALLDATE>23/11/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Google Chrome]]></NAME>
+         <VERSION>112.0.5615.138</VERSION>
+         <PUBLISHER>Google LLC</PUBLISHER>
+         <INSTALLDATE>28/12/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[HP Connection Optimizer]]></NAME>
+         <VERSION>2.0.15.0</VERSION>
+         <PUBLISHER>HP Inc.</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[HP Hotkey Support]]></NAME>
+         <VERSION>6.2.52.1</VERSION>
+         <PUBLISHER>HP Inc.</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[HP PC Hardware Diagnostics UEFI]]></NAME>
+         <VERSION>7.6.0.0</VERSION>
+         <PUBLISHER>HP</PUBLISHER>
+         <INSTALLDATE>11/06/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[HP System Default Settings]]></NAME>
+         <VERSION>1.4.8.2</VERSION>
+         <PUBLISHER>HP Inc.</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Chipset Device Software]]></NAME>
+         <VERSION>10.1.18019.8144</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Icls]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) LMS]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Management Engine Components]]></NAME>
+         <VERSION>1932.12.0.1298</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Management Engine Components]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Management Engine Driver]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) OEM Extension]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Processor Graphics]]></NAME>
+         <VERSION>26.20.100.7157</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Wireless Manageability Driver]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Intel(R) Wireless Manageability Driver Extension]]></NAME>
+         <VERSION>1.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Edge]]></NAME>
+         <VERSION>112.0.1722.46</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>21/04/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Edge Update]]></NAME>
+         <VERSION>1.3.175.27</VERSION>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Policy Platform]]></NAME>
+         <VERSION>68.1.1010.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Silverlight]]></NAME>
+         <VERSION>5.1.50907.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>21/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft VC++ redistributables repacked.]]></NAME>
+         <VERSION>12.0.0.0</VERSION>
+         <PUBLISHER>Intel Corporation</PUBLISHER>
+         <INSTALLDATE>14/11/2019</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660]]></NAME>
+         <VERSION>12.0.40660.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40660]]></NAME>
+         <VERSION>12.0.40660.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40660]]></NAME>
+         <VERSION>12.0.40660</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40660]]></NAME>
+         <VERSION>12.0.40660</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40660]]></NAME>
+         <VERSION>12.0.40660</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40660]]></NAME>
+         <VERSION>12.0.40660</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914.0</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X64 Additional Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X86 Additional Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.28.29914]]></NAME>
+         <VERSION>14.28.29914</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>30/09/2021</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Netskope Client]]></NAME>
+         <VERSION>99.0.7.1144</VERSION>
+         <PUBLISHER>Netskope, Inc.</PUBLISHER>
+         <INSTALLDATE>13/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[PDFCreator]]></NAME>
+         <VERSION>3.1.2</VERSION>
+         <PUBLISHER>pdfforge GmbH</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Software para dispositivos de chipset Intel®]]></NAME>
+         <VERSION>10.1.18019.8144</VERSION>
+         <PUBLISHER>Intel(R) Corporation</PUBLISHER>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Swivel Taskbar Client]]></NAME>
+         <VERSION>1.6.6.1</VERSION>
+         <PUBLISHER>Swivel Secure</PUBLISHER>
+         <INSTALLDATE>16/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[Teams Machine-Wide Installer]]></NAME>
+         <VERSION>1.3.0.3564</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/03/2020</INSTALLDATE>
+      </SOFTWARES>
+      <SOFTWARES>
+         <NAME><![CDATA[WebView2 Runtime de Microsoft Edge]]></NAME>
+         <VERSION>113.0.1774.42</VERSION>
+         <PUBLISHER>Microsoft Corporation</PUBLISHER>
+         <INSTALLDATE>14/05/2023</INSTALLDATE>
+      </SOFTWARES>
+      <MEMORIES>
+         <CAPACITY>8192</CAPACITY>
+         <CAPTION>Memoria física</CAPTION>
+         <DESCRIPTION>Memoria física</DESCRIPTION>
+         <FORMFACTOR>8</FORMFACTOR>
+         <REMOVABLE/>
+         <PURPOSE/>
+         <SPEED>2667</SPEED>
+         <TYPE>ChannelB</TYPE>
+         <NUMSLOTS>1</NUMSLOTS>
+         <SERIALNUMBER/>
+         <MANUFACTURER>Hynix/Hyundai</MANUFACTURER>
+      </MEMORIES>
+      <VIDEOS>
+         <CHIPSET>Intel(R) UHD Graphics Family</CHIPSET>
+         <MEMORY>1024</MEMORY>
+         <NAME>Intel(R) UHD Graphics 630</NAME>
+         <RESOLUTION>1920x1080</RESOLUTION>
+         <PCISLOT>1</PCISLOT>
+      </VIDEOS>
+      <SOUNDS>
+         <DESCRIPTION>Sonido Intel(R) para pantallas</DESCRIPTION>
+         <MANUFACTURER>Intel(R) Corporation</MANUFACTURER>
+         <NAME>Sonido Intel(R) para pantallas</NAME>
+      </SOUNDS>
+      <SOUNDS>
+         <DESCRIPTION>Synaptics HD Audio</DESCRIPTION>
+         <MANUFACTURER>Synaptics</MANUFACTURER>
+         <NAME>Synaptics HD Audio</NAME>
+      </SOUNDS>
+      <USERS>
+         <LOGIN>xxxxxxx</LOGIN>
+      </USERS>
+      <NETWORKS>
+         <IPADDRESS>192.168.1.133</IPADDRESS>
+         <IPADDRESS6>fe80::9bbb:c6ae:3cd5:d9fb</IPADDRESS6>
+         <IPADDRESS6>2a0c:5a80:140d:4400:c480:da92:e839:ec9d</IPADDRESS6>
+         <IPADDRESS6>2a0c:5a80:140d:4400:70f7:45d7:71fd:4d85</IPADDRESS6>
+         <IPADDRESS6>2a0c:5a80:140d:4400:c3a:ccfe:ecdc:42b4</IPADDRESS6>
+         <IPADDRESS6>2a0c:5a80:140d:4400:89d2:18f3:d43:2dfb</IPADDRESS6>
+         <DESCRIPTION>Intel(R) Ethernet Connection (7) I219-LM</DESCRIPTION>
+         <IPMASK>255.255.255.0, 64, 128, 128, 128, 64</IPMASK>
+         <IPDHCP>192.168.1.1</IPDHCP>
+         <IPGATEWAY>192.168.1.1, fe80::1</IPGATEWAY>
+         <MACADDR>9C:7B:EF:B3:50:96</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <IPADDRESS>172.27.192.8</IPADDRESS>
+         <DESCRIPTION>PANGP Virtual Ethernet Adapter #2</DESCRIPTION>
+         <IPMASK>255.255.255.255</IPMASK>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>02:50:41:00:00:01</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IP)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>A8:79:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IP)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>AA:DF:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IP)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>AC:32:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IPv6)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>A8:79:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IPv6)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>AA:DF:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (IPv6)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>AC:32:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (Network Monitor)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>A8:79:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (Network Monitor)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>AA:DF:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <NETWORKS>
+         <DESCRIPTION>WAN Miniport (Network Monitor)</DESCRIPTION>
+         <IPMASK/>
+         <IPDHCP/>
+         <IPGATEWAY/>
+         <MACADDR>AC:32:20:52:41:53</MACADDR>
+      </NETWORKS>
+      <DRIVES>
+         <DESCRIPTION>Disco fijo local</DESCRIPTION>
+         <FILESYSTEM>NTFS</FILESYSTEM>
+         <FREE>169840640</FREE>
+         <LABEL>KBG30ZMV256G KIOXIA</LABEL>
+         <LETTER>Windows</LETTER>
+         <TOTAL>249083904</TOTAL>
+         <VOLUMN>C:</VOLUMN>
+      </DRIVES>
+   </CONTENT>
+   <DEVICEID>16811420</DEVICEID>
+   <QUERY>INVENTORY</QUERY>
+   <PROLOG/>
+</REQUEST>


### PR DESCRIPTION
Add capability to manage several IPV4 and IPV6

Add tow example (usefull for GLPI unit test) : 
- computer_with_several_ipv4.json
- computer_with_several_ipv6.json

this particularity has been seen from ```SCCM``` plugin 

![image](https://github.com/glpi-project/inventory_format/assets/7335054/78f4eaff-1869-40ce-a19b-2bda902abc63)

which generates the following XML:

```xml
<NETWORKS>
    <IPADDRESS>169.254.41.148</IPADDRESS>
    <IPADDRESS>192.168.0.225</IPADDRESS>
    <IPADDRESS>10.50.78.89</IPADDRESS>
    <IPADDRESS6>fe80::c0b2:cf62:cba8:8d8</IPADDRESS6>
    <DESCRIPTION>Intel(R) Ethernet Connection (7) I219-V</DESCRIPTION>
    <IPMASK>255.255.255.0, 255.255.255.0, 255.255.255.128, 64</IPMASK>
    <IPDHCP/>
    <IPGATEWAY>10.50.78.19</IPGATEWAY>
    <MACADDR>04:92:26:D7:AC:51</MACADDR>
</NETWORKS>

<NETWORKS>
    <IPADDRESS>192.168.1.133</IPADDRESS>
    <IPADDRESS6>fe80::9bbb:c6ae:3cd5:d9fb</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:c480:da92:e839:ec9d</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:70f7:45d7:71fd:4d85</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:c3a:ccfe:ecdc:42b4</IPADDRESS6>
    <IPADDRESS6>2a0c:5a80:140d:4400:89d2:18f3:d43:2dfb</IPADDRESS6>
    <DESCRIPTION>Intel(R) Ethernet Connection (7) I219-LM</DESCRIPTION>
    <IPMASK>255.255.255.0, 64, 128, 128, 128, 64</IPMASK>
    <IPDHCP>192.168.1.1</IPDHCP>
    <IPGATEWAY>192.168.1.1, fe80::1</IPGATEWAY>
    <MACADDR>9C:7B:EF:B3:50:96</MACADDR>
</NETWORKS>
```

Code developed with great care by @tolemac 

I just added the unit tests

Usefull for this -> https://github.com/glpi-project/glpi/pull/14731

Best regards



