### PR TITLE
fix(inventory): keep empty node to handle deletion

### DIFF
--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -509,6 +509,12 @@ class Converter
             if (isset($data['content'][$array]) && !array_is_list($data['content'][$array])) {
                 $data['content'][$array] = [$data['content'][$array]];
             }
+
+            //set empty array for virtualmachine if not set
+            //Inventory->processInventoryData() can handle this key and manage the absence/deletion of VMs.
+            if (!isset($data['content'][$array]) && $array == 'virtualmachines') {
+                $data['content'][$array] = [];
+            }
         }
 
         $sub_arrays = [


### PR DESCRIPTION
When the ```VIRTUALMACHINES``` node is empty 

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<REQUEST>
  <CONTENT>
    <BIOS>
      <ASSETTAG></ASSETTAG>
      <BDATE>2018-02-08T00:00:00Z</BDATE>
      <BVERSION>1.3.7</BVERSION>
      <MSN>2YR88P2</MSN>
      <SMANUFACTURER>Dell Inc.</SMANUFACTURER>
      <SMODEL>PowerEdge R640</SMODEL>
      <SSN>2YR88P2</SSN>
    </BIOS>
    <HARDWARE>
      <DNS>10.100.230.2/10.100.230.4</DNS>
      <MEMORY>130625</MEMORY>
      <NAME>ESX</NAME>
      <UUID>ddfgdfg-dfgdfgd-gdfgdfg-dfgdfgdfg-sdfsdf</UUID>
      <VMSYSTEM>Physical</VMSYSTEM>
      <WORKGROUP>teclib.fr</WORKGROUP>
    </HARDWARE>
    <VERSIONCLIENT>GLPI-Agent_v1.4-1</VERSIONCLIENT>
    <VIRTUALMACHINES>
    </VIRTUALMACHINES>
  </CONTENT>
  <DEVICEID>esx</DEVICEID>
  <QUERY>INVENTORY</QUERY>
</REQUEST>

```
it is not kept by the converter

On GLPI ```Inventory->processInventoryData()``` therefore never passes into ```Glpi\Inventory\Asset\VirtualMachine``` and does not delete virtual machines (If any are added before). 