### PR TITLE
Clarify antivirus base_creation property usage and format

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -97,8 +97,8 @@
                 "$ref": "#/definitions/date"
               },
               "base_creation": {
-                "$comment": "What type is it? A date?",
-                "type": "string"
+                "title": "Signatures base creation date",
+                "$ref": "#/definitions/date"
               },
               "base_version": {
                 "type": "string",


### PR DESCRIPTION
As a side note, this property wasn't use anywhere until today: nightly glpi-agent will now support this property for Microsoft Defender antivirus on MacOSX and linux.
This property is actually not analyzed in GLPI.