### PR TITLE
Ignore XML nodes attributes during conversion

### DIFF
--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1633,6 +1633,9 @@ class Converter
                     $device_info['credentials'] = $device[$key];
                     unset($device[$key]);
                     break;
+                case '@attributes':
+                    // Just ignore attributes
+                    break;
                 default:
                     throw new \RuntimeException('Key ' . $key . ' is not handled in network discovery conversion');
             }


### PR DESCRIPTION
This permits injection of netdiscovery XML files generated by [GLPI-Agent ToolBox plugin](https://glpi-agent.readthedocs.io/en/latest/plugins/toolbox-plugin.html).