### PR TITLE
fix(shema): handle old <ERROR> node from netinventory

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -108,6 +108,19 @@
             "additionalProperties": false
           }
         },
+        "error": {
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "message": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        },
         "batteries": {
           "type": "array",
           "items": {

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1527,6 +1527,7 @@ class Converter
                     break;
                 case "cartridges":
                 case "pagecounters":
+                case "error":
                     $data['content'][$key] = $device[$key];
                     break;
                 default:


### PR DESCRIPTION
This king of XML  file

```xml
<?xml version="1.0" encoding="UTF-8"?>
<REQUEST>
  <CONTENT>
    <DEVICE>
      <ERROR>
        <ID>210</ID>
        <MESSAGE>SNMP communication error: no response from host 13.22.7.57</MESSAGE>
        <TYPE>Printer</TYPE>
      </ERROR>
    </DEVICE>
    <MODULEVERSION>5.1</MODULEVERSION>
    <PROCESSNUMBER>5618276</PROCESSNUMBER>
  </CONTENT>
  <DEVICEID>hotline-xxxxx-2023-05-12-18-48-55</DEVICEID>
  <QUERY>SNMPQUERY</QUERY>
</REQUEST>
```

 thrown an error from GLPI

```
glpiphplog.CRITICAL:   *** Uncaught Exception RuntimeException: Key error is not handled in network devices conversion in /var/www/glpi/vendor/glpi-project/inventory_format/lib/php/Converter.php at line 1529
  Backtrace :
  ...ject/inventory_format/lib/php/Converter.php:380 Glpi\Inventory\Converter->convertNetworkInventory()
  ...ject/inventory_format/lib/php/Converter.php:323 Glpi\Inventory\Converter->convertTo01()
  src/Inventory/Inventory.php:141                    Glpi\Inventory\Converter->convert()
  src/Inventory/Request.php:265                      Glpi\Inventory\Inventory->setData()
  src/Inventory/Request.php:250                      Glpi\Inventory\Request->network()
  src/Inventory/Request.php:98                       Glpi\Inventory\Request->networkInventory()
  src/Agent/Communication/AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:269    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  src/Inventory/Conf.php:242                         Glpi\Agent\Communication\AbstractRequest->handleRequest()
  src/Inventory/Conf.php:187                         Glpi\Inventory\Conf->importContentFile()
  src/Inventory/Conf.php:287                         Glpi\Inventory\Conf->importFiles()
  front/inventory.conf.php:47                        Glpi\Inventory\Conf->displayImportFiles()
  public/index.php:82                                require()
```