### PR TITLE
Single vlan handling fix

### DIFF
--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1410,7 +1410,7 @@ class Converter
                     foreach ($data['content']['network_ports'] as &$netport) {
                         if (isset($netport['vlans'])) {
                             $netport['vlans'] = is_array($netport['vlans']['vlan'])
-                                &&  array_is_list($netport['vlans']['vlan'])
+                                && array_is_list($netport['vlans']['vlan'])
                                 ? $netport['vlans']['vlan']
                                 : [$netport['vlans']['vlan']];
                         }

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1409,9 +1409,10 @@ class Converter
                     //check for arrays
                     foreach ($data['content']['network_ports'] as &$netport) {
                         if (isset($netport['vlans'])) {
-                            $netport['vlans'] = array_is_list($netport['vlans']['vlan']) ?
-                                $netport['vlans']['vlan'] :
-                                [$netport['vlans']['vlan']];
+                            $netport['vlans'] = is_array($netport['vlans']['vlan'])
+                                &&  array_is_list($netport['vlans']['vlan'])
+                                ? $netport['vlans']['vlan']
+                                : [$netport['vlans']['vlan']];
                         }
                         if (isset($netport['connections']['cdp'])) {
                             $netport['lldp'] = (bool)$netport['connections']['cdp'];


### PR DESCRIPTION
glpi-injector fails with
`Loading test.xml...ERROR: 500 Internal Server Error, array_is_list(): Argument #1 ($array) must be of type array, string given, called in /glpi/vendor/glpi-project/inventory_format/lib/php/Converter.php on line 1421`
on the following data:
```xml
        <PORT>
          <VLANS>
            <VLAN>
              <NAME>default</NAME>
              <NUMBER>1</NUMBER>
            </VLAN>
          </VLANS>
        </PORT>
```