### PR TITLE
PHPStan deprecation rules needs the PHPStan plugin loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     },
     "bin": ["bin/convert", "bin/build_hw_jsons", "bin/refresh_hw_sources","bin/validate"],
     "require-dev": {
+        "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpunit/phpunit": "^9.6",
@@ -45,6 +46,9 @@
         "platform": {
             "php": "7.4.99"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }


### PR DESCRIPTION
The package is not loaded automatically unless the `phpstan/extension-installer` composer plugin is active.