### PR TITLE
Add method to make schema validation more flexible 

### DIFF
--- a/bin/convert
+++ b/bin/convert
@@ -57,7 +57,7 @@ try {
     }
 
     $json = $converter->convert($xml->asXML());
-    $converter->validate(json_decode($json));
+    $converter->getSchema()->validate(json_decode($json));
 
     if ($json_path !== null) {
         file_put_contents($json_path, $json);

--- a/bin/validate
+++ b/bin/validate
@@ -33,10 +33,10 @@ if (!file_exists($json_path)) {
 }
 
 try {
-    $converter = new Glpi\Inventory\Converter;
+    $schema = new \Glpi\Inventory\Schema();
 
     $json_str = file_get_contents($json_path);
-    $converter->validate(json_decode($json_str));
+    $schema->validate(json_decode($json_str));
 } catch (\Exception $e) {
     echo "File: $json_path\n";
     echo $e->getMessage();

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-curl": "*"
     },
     "autoload": {
-        "files": ["lib/php/Converter.php", "lib/php/FilesToJSON.php"]
+        "files": ["lib/php/Schema.php", "lib/php/Converter.php", "lib/php/FilesToJSON.php"]
     },
     "bin": ["bin/convert", "bin/build_hw_jsons", "bin/refresh_hw_sources","bin/validate"],
     "require-dev": {

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://glpi-project.org/inventory.json",
   "type": "object",
   "title": "GLPI Inventory Schema",
-  "version": "0.1",
+  "version": 1.0,
   "definitions": {
     "datetime": {
       "type": "string",

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -24,10 +24,8 @@ use UnexpectedValueException;
  */
 class Converter
 {
-    public const LAST_VERSION = 0.1;
-
-    /** @var ?float */
-    private ?float $target_version;
+    /** @var float */
+    private float $target_version;
 
     private Schema $schema;
     /** @var bool */
@@ -40,7 +38,7 @@ class Converter
 
     /** @var array<string, float> */
     private array $mapping = [
-        '01'   => 0.1
+        '01'   => 1.0
     ];
 
     /**
@@ -71,18 +69,10 @@ class Converter
      *
      * @param ?float $target_version JSON schema based version to target. Use last version if null.
      */
-    public function __construct($target_version = null)
+    public function __construct(?float $target_version = null)
     {
         $this->schema = new Schema();
-        if ($target_version === null) {
-            $target_version = self::LAST_VERSION;
-        }
-
-        if (!is_double($target_version)) {
-            throw new UnexpectedValueException('Version must be a double!');
-        }
-
-        $this->target_version = $target_version;
+        $this->target_version = $target_version ?? $this->schema->getVersion();
     }
 
     /**
@@ -92,7 +82,7 @@ class Converter
      */
     public function getTargetVersion(): float
     {
-        return $this->target_version ?? self::LAST_VERSION;
+        return $this->target_version;
     }
 
     /**
@@ -204,7 +194,17 @@ class Converter
     }
 
     /**
-     * Converts to inventory format 0.1
+     * Get versions mapping
+     *
+     * @return array<string, float>
+     */
+    public function getMappings(): array
+    {
+        return $this->mapping;
+    }
+
+    /**
+     * Converts to inventory format 1.0
      *
      * @param array<string, mixed> $data Contents
      *

--- a/lib/php/Schema.php
+++ b/lib/php/Schema.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * © Teclib' and contributors.
+ *
+ * This file is part of GLPI inventory format.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Glpi\Inventory;
+
+use Exception;
+use RuntimeException;
+use Swaggest\JsonSchema\Context;
+
+/**
+ * Handle inventory JSON Schema
+ *
+ * @author Johan Cwiklinski <jcwiklinski@teclib.com>
+ */
+class Schema
+{
+    public const LAST_VERSION = 0.1;
+
+    /** @var array<string, array<int, string>> */
+    private array $patterns;
+    /** @var array<string, array<string, string>> */
+    private array $extra_properties = [];
+    /** @var array<string, array<string, array<string, string>>> */
+    private array $extra_sub_properties = [];
+    /** @var array<string> */
+    private array $extra_itemtypes = [];
+    /** @var bool */
+    private bool $strict_schema = true;
+
+    /**
+     * Add new supported item types
+     *
+     * @param array<string> $itemtypes
+     * @return $this
+     */
+    public function setExtraItemtypes(array $itemtypes): self
+    {
+        $this->extra_itemtypes = $itemtypes;
+        return $this;
+    }
+
+    /**
+     * Build (extended) JSON schema
+     *
+     * @return object
+     */
+    public function build(): object
+    {
+        $string = file_get_contents($this->getPath());
+        if ($string === false) {
+            throw new RuntimeException('Unable to read schema file');
+        }
+        $schema = json_decode($string);
+
+        $known_itemtypes = [];
+        preg_match('/\^\((.+)\)\$/', $schema->properties->itemtype->pattern, $known_itemtypes);
+        if (isset($known_itemtypes[1])) {
+            $known_itemtypes = explode('|', $known_itemtypes[1]);
+            foreach ($this->extra_itemtypes as $extra_itemtype) {
+                if (!in_array($extra_itemtype, $known_itemtypes)) {
+                    $known_itemtypes[] = addslashes($extra_itemtype);
+                }
+            }
+            $schema->properties->itemtype->pattern = sprintf(
+                '^(%s)$',
+                implode('|', $known_itemtypes)
+            );
+        }
+
+        $properties = $schema->properties->content->properties;
+
+        foreach ($this->extra_properties as $extra_property => $extra_config) {
+            if (!property_exists($properties, $extra_property)) {
+                $properties->$extra_property = json_decode((string)json_encode($extra_config));
+            } else {
+                trigger_error(
+                    sprintf('Property %1$s already exists in schema.', $extra_property),
+                    E_USER_WARNING
+                );
+            }
+        }
+
+        foreach ($this->extra_sub_properties as $extra_sub_property => $extra_sub_config) {
+            if (property_exists($properties, $extra_sub_property)) {
+                foreach ($extra_sub_config as $subprop => $subconfig) {
+                    $type = $properties->$extra_sub_property->type;
+                    switch ($type) {
+                        case 'array':
+                            if (!property_exists($properties->$extra_sub_property->items->properties, $subprop)) {
+                                $properties->$extra_sub_property->items->properties->$subprop =
+                                    json_decode((string)json_encode($subconfig));
+                            } else {
+                                trigger_error(
+                                    sprintf('Property %1$s already exists in schema.', $subprop),
+                                    E_USER_WARNING
+                                );
+                            }
+                            break;
+                        case 'object':
+                            if (!property_exists($properties->$extra_sub_property->properties, $subprop)) {
+                                $properties->$extra_sub_property->properties->$subprop =
+                                    json_decode((string)json_encode($subconfig));
+                            } else {
+                                trigger_error(
+                                    sprintf(
+                                        'Property %1$s/%2$s already exists in schema.',
+                                        $extra_sub_property,
+                                        $subprop
+                                    ),
+                                    E_USER_WARNING
+                                );
+                            }
+                            break;
+                        default:
+                            trigger_error('Unknown type ' . $type, E_USER_WARNING);
+                    }
+                }
+            } else {
+                trigger_error(
+                    sprintf('Property %1$s does not exists in schema.', $extra_sub_property),
+                    E_USER_WARNING
+                );
+            }
+        }
+
+        if ($this->strict_schema === false) {
+            $this->buildFlexibleSchema($schema->properties->content);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Get path to schema
+     *
+     * @return string
+     */
+    public function getPath(): string
+    {
+        $schema_path = realpath(__DIR__ . '/../../inventory.schema.json');
+        if ($schema_path === false) {
+            throw new RuntimeException('Schema file not found!');
+        }
+        return $schema_path;
+    }
+
+    /**
+     * Add extra properties to schema
+     *
+     * @param array<string, array<string, string>> $properties
+     * @return $this
+     */
+    public function setExtraProperties(array $properties): self
+    {
+        $this->extra_properties = $properties;
+        return $this;
+    }
+
+    /**
+     * Add extra sub-properties to schema
+     *
+     * @param array<string, array<string, array<string, string>>> $properties
+     * @return $this
+     */
+    public function setExtraSubProperties(array $properties): self
+    {
+        $this->extra_sub_properties = $properties;
+        return $this;
+    }
+
+    /**
+     * Load schema patterns that will be used to validate
+     *
+     * @return void
+     */
+    public function loadPatterns(): void
+    {
+        $string = file_get_contents($this->getPath());
+        if ($string === false) {
+            throw new RuntimeException('Unable to read schema file');
+        }
+        $json = json_decode($string, true);
+
+        $this->patterns['networks_types'] = explode(
+            '|',
+            str_replace(
+                ['^(', ')$'],
+                ['', ''],
+                $json['properties']['content']['properties']['networks']['items']['properties']['type']['pattern']
+            )
+        );
+    }
+
+    /**
+     * Get available schema patterns
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function getPatterns(): array
+    {
+        return $this->patterns;
+    }
+
+    /**
+     * Set schema validation strict (no additional properties allowed anywhere)
+     *
+     * @return self
+     */
+    public function setStrict(): self
+    {
+        $this->strict_schema = true;
+        return $this;
+    }
+
+    /**
+     * Set schema validation strict (no additional properties allowed anywhere)
+     *
+     * @return self
+     */
+    public function setFlexible(): self
+    {
+        $this->strict_schema = false;
+        return $this;
+    }
+
+    /**
+     * Build schema flexible (remove all additionalProperties)
+     *
+     * @param mixed $schemapart
+     *
+     * @return void
+     */
+    private function buildFlexibleSchema(&$schemapart)
+    {
+        foreach ($schemapart as $key => $value) {
+            if (is_object($value) || is_array($value)) {
+                $this->buildFlexibleSchema($value);
+            } else {
+                if ($key == 'additionalProperties') {
+                    unset($schemapart->$key);
+                }
+            }
+        }
+    }
+
+    /**
+     * Do validation (against last schema only!)
+     *
+     * @param mixed $json Converted data to validate
+     *
+     * @return boolean
+     */
+    public function validate($json): bool
+    {
+        try {
+            $schema = \Swaggest\JsonSchema\Schema::import($this->build());
+
+            $context = new Context();
+            $context->tolerateStrings = (!defined('TU_USER'));
+            $schema->in($json, $context);
+            return true;
+        } catch (Exception $e) {
+            throw new RuntimeException(
+                sprintf(
+                    "JSON does not validate. Violations:\n%1\$s\n",
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+}

--- a/lib/php/Schema.php
+++ b/lib/php/Schema.php
@@ -22,8 +22,6 @@ use Swaggest\JsonSchema\Context;
  */
 class Schema
 {
-    public const LAST_VERSION = 0.1;
-
     /** @var array<string, array<int, string>> */
     private array $patterns;
     /** @var array<string, array<string, string>> */
@@ -275,5 +273,15 @@ class Schema
                 )
             );
         }
+    }
+
+    /**
+     * Get current schema version
+     *
+     * @return float
+     */
+    public function getVersion(): float
+    {
+        return $this->build()->version; //@phpstan-ignore-line: version does exist.
     }
 }

--- a/tests/Glpi/Inventory/tests/units/Converter.php
+++ b/tests/Glpi/Inventory/tests/units/Converter.php
@@ -23,15 +23,11 @@ class Converter extends TestCase
     public function testConstructor(): void
     {
         $instance = new \Glpi\Inventory\Converter();
-        $this->assertSame($instance::LAST_VERSION, $instance->getTargetVersion());
+        $this->assertSame($instance->getSchema()->getVersion(), $instance->getTargetVersion());
 
         $ver = 156.2;
         $instance = new \Glpi\Inventory\Converter($ver);
         $this->assertSame($ver, $instance->getTargetVersion());
-
-        $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Version must be a double!');
-        new \Glpi\Inventory\Converter('abcde'); //@phpstan-ignore-line
     }
 
     /**
@@ -56,7 +52,7 @@ class Converter extends TestCase
     public function testGetMethods(): void
     {
         $expected = ['convertTo01'];
-        $instance = new \Glpi\Inventory\Converter(0.1);
+        $instance = new \Glpi\Inventory\Converter(1.0);
         $this->assertSame($expected, $instance->getMethods());
     }
 
@@ -801,5 +797,14 @@ ARM Bios Ver 7.59u v46 454MHz B987-M995-F80-O0,0 MAC:00042d076b88"
     {
         $instance = new \Glpi\Inventory\Converter();
         $this->assertSame($expected, $instance->convertMemory($orig));
+    }
+
+    public function testHasLatestVersion(): void
+    {
+        $instance = new \Glpi\Inventory\Converter();
+        $this->assertContains(
+            $instance->getSchema()->getVersion(),
+            $instance->getMappings()
+        );
     }
 }

--- a/tests/Glpi/Inventory/tests/units/Converter.php
+++ b/tests/Glpi/Inventory/tests/units/Converter.php
@@ -961,5 +961,17 @@ ARM Bios Ver 7.59u v46 454MHz B987-M995-F80-O0,0 MAC:00042d076b88"
         $this->assertSame($expected, $instance->convertMemory($orig));
     }
 
+    public function testFlexibleSchema(): void
+    {
+        $json_additionnal = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'additional' => ['name' => 'my extra data']]]));
+        $instance = new \Glpi\Inventory\Converter();
+        $instance->setFlexibleSchema();
+        $this->assertTrue($instance->validate($json_additionnal));
 
+        //tests same JSON fails with strict schema
+        $instance->setStrictSchema();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Additional properties not allowed: additional');
+        $this->assertTrue($instance->validate($json_additionnal));
+    }
 }

--- a/tests/Glpi/Inventory/tests/units/Converter.php
+++ b/tests/Glpi/Inventory/tests/units/Converter.php
@@ -49,18 +49,6 @@ class Converter extends TestCase
     }
 
     /**
-     * Test schema path
-     *
-     * @return void
-     */
-    public function testSchemaPath(): void
-    {
-        $expected = realpath(TU_DIR . '/../inventory.schema.json');
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertSame($expected, $instance->getSchemaPath());
-    }
-
-    /**
      * Test conversion methods list
      *
      * @return void
@@ -697,152 +685,6 @@ ARM Bios Ver 7.59u v46 454MHz B987-M995-F80-O0,0 MAC:00042d076b88"
         );
     }
 
-    public function testValidateOK(): void
-    {
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertTrue($instance->validate($json));
-    }
-
-    public function testValidateVersionClient(): void
-    {
-        //required "versionclient" is missing
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['hardware' => ['name' => 'my inventory']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Required property missing: versionclient');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateUnknownItemtype(): void
-    {
-        //itemtype \Glpi\Custom\Asset\Mine is unknown
-        $itemtype = '\Glpi\Custom\Asset\Mine';
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'itemtype' => $itemtype, 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('\\\\Glpi\\\\Custom\\\\Asset\\\\Mine" does not match to ^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateNewItemtype(): void
-    {
-        //itemtype \Glpi\Custom\Asset\Mine is unknown
-        $itemtype = '\Glpi\Custom\Asset\Mine';
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'itemtype' => $itemtype, 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraItemtypes([$itemtype]));
-        $this->assertTrue($instance->validate($json));
-    }
-
-    public function testValidateUnknownExtraPlugin_node(): void
-    {
-        //extra "plugin_node" is unknown
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'plugin_node' => 'plugin node']]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Additional properties not allowed: plugin_node');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateExtraPlugin_node(): void
-    {
-        //add extra "plugin_node" as string
-        $extra_prop = ['plugin_node' => ['type' => 'string']];
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'plugin_node' => 'plugin node']]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraProperties($extra_prop));
-        $this->assertTrue($instance->validate($json));
-    }
-
-    public function testValidateUnknownHwPlugin_node(): void
-    {
-        //extra "hardware/hw_plugin_node" is unknown
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['hw_plugin_node' => 'plugin node']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Additional properties not allowed: hw_plugin_node');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateHwPlugin_node(): void
-    {
-        //add extra "hardware/hw_plugin_node" as string
-        $extra_sub_prop = ['hardware' => ['hw_plugin_node' => ['type' => 'string']]];
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['hw_plugin_node' => 'plugin node']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraSubProperties($extra_sub_prop));
-        $this->assertTrue($instance->validate($json));
-    }
-
-    public function testValidateUnknownVmPlugin_node(): void
-    {
-        //extra "virtualmachines/vm_plugin_node" is unknown
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'virtualmachines' => [['name' => 'My VM', 'vmtype' => 'libvirt', 'vm_plugin_node' => 'plugin node']]]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Additional properties not allowed: vm_plugin_node');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateVmPlugin_node(): void
-    {
-        //add extra "virtualmachines/vm_plugin_node" as string
-        $extra_sub_prop = ['virtualmachines' => ['vm_plugin_node' => ['type' => 'string']]];
-        $json = json_decode(json_encode([
-            'deviceid' => 'myid',
-            'content' => [
-                'versionclient' => 'GLPI-Agent_v1.0',
-                'virtualmachines' => [
-                    [
-                        'name' => 'My VM',
-                        'vmtype' => 'libvirt',
-                        'vm_plugin_node' => 'plugin node'
-                    ]
-                ]
-            ]
-        ]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraSubProperties($extra_sub_prop));
-        $this->assertTrue($instance->validate($json));
-    }
-
-    public function testValidateAlreadyExistingExtraNode(): void
-    {
-        //try add extra node already existing
-        $extra_prop = ['accesslog' => ['type' => 'string']];
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0']]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraProperties($extra_prop));
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Property accesslog already exists in schema.');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateUAlreadyExistingExtraSubNode(): void
-    {
-        //try add extra sub node already existing
-        $extra_sub_prop = ['hardware' => ['chassis_type' => ['type' => 'string']]];
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0']]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraSubProperties($extra_sub_prop));
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Property hardware/chassis_type already exists in schema.');
-        $this->assertFalse($instance->validate($json));
-    }
-
-    public function testValidateMissingParentSubNode(): void
-    {
-        //try add extra sub node with missing parent
-        $extra_sub_prop = ['unknown' => ['chassis_type' => ['type' => 'string']]];
-        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0']]));
-        $instance = new \Glpi\Inventory\Converter();
-        $this->assertInstanceOf(\Glpi\Inventory\Converter::class, $instance->setExtraSubProperties($extra_sub_prop));
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Property unknown does not exists in schema.');
-        $this->assertFalse($instance->validate($json));
-    }
-
     public function testAssetTagFromDiscovery(): void
     {
         $xml_path = realpath(TU_DIR . '/data/16.xml');
@@ -959,19 +801,5 @@ ARM Bios Ver 7.59u v46 454MHz B987-M995-F80-O0,0 MAC:00042d076b88"
     {
         $instance = new \Glpi\Inventory\Converter();
         $this->assertSame($expected, $instance->convertMemory($orig));
-    }
-
-    public function testFlexibleSchema(): void
-    {
-        $json_additionnal = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'additional' => ['name' => 'my extra data']]]));
-        $instance = new \Glpi\Inventory\Converter();
-        $instance->setFlexibleSchema();
-        $this->assertTrue($instance->validate($json_additionnal));
-
-        //tests same JSON fails with strict schema
-        $instance->setStrictSchema();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Additional properties not allowed: additional');
-        $this->assertTrue($instance->validate($json_additionnal));
     }
 }

--- a/tests/Glpi/Inventory/tests/units/Schema.php
+++ b/tests/Glpi/Inventory/tests/units/Schema.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * © Teclib' and contributors.
+ *
+ * This file is part of GLPI inventory format.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Glpi\Inventory\tests\units;
+
+use PHPUnit\Framework\TestCase;
+
+class Schema extends TestCase
+{
+    /**
+     * Test schema path
+     *
+     * @return void
+     */
+    public function testSchemaPath(): void
+    {
+        $expected = realpath(TU_DIR . '/../inventory.schema.json');
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertSame($expected, $instance->getPath());
+    }
+
+    public function testValidateOK(): void
+    {
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertTrue($instance->validate($json));
+    }
+
+    public function testValidateVersionClient(): void
+    {
+        //required "versionclient" is missing
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['hardware' => ['name' => 'my inventory']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Required property missing: versionclient');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateUnknownItemtype(): void
+    {
+        //itemtype \Glpi\Custom\Asset\Mine is unknown
+        $itemtype = '\Glpi\Custom\Asset\Mine';
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'itemtype' => $itemtype, 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('\\\\Glpi\\\\Custom\\\\Asset\\\\Mine" does not match to ^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateNewItemtype(): void
+    {
+        //itemtype \Glpi\Custom\Asset\Mine is unknown
+        $itemtype = '\Glpi\Custom\Asset\Mine';
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'itemtype' => $itemtype, 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraItemtypes([$itemtype]));
+        $this->assertTrue($instance->validate($json));
+    }
+
+    public function testValidateUnknownExtraPlugin_node(): void
+    {
+        //extra "plugin_node" is unknown
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'plugin_node' => 'plugin node']]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Additional properties not allowed: plugin_node');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateExtraPlugin_node(): void
+    {
+        //add extra "plugin_node" as string
+        $extra_prop = ['plugin_node' => ['type' => 'string']];
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'plugin_node' => 'plugin node']]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraProperties($extra_prop));
+        $this->assertTrue($instance->validate($json));
+    }
+
+    public function testValidateUnknownHwPlugin_node(): void
+    {
+        //extra "hardware/hw_plugin_node" is unknown
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['hw_plugin_node' => 'plugin node']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Additional properties not allowed: hw_plugin_node');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateHwPlugin_node(): void
+    {
+        //add extra "hardware/hw_plugin_node" as string
+        $extra_sub_prop = ['hardware' => ['hw_plugin_node' => ['type' => 'string']]];
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['hw_plugin_node' => 'plugin node']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraSubProperties($extra_sub_prop));
+        $this->assertTrue($instance->validate($json));
+    }
+
+    public function testValidateUnknownVmPlugin_node(): void
+    {
+        //extra "virtualmachines/vm_plugin_node" is unknown
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'virtualmachines' => [['name' => 'My VM', 'vmtype' => 'libvirt', 'vm_plugin_node' => 'plugin node']]]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Additional properties not allowed: vm_plugin_node');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateVmPlugin_node(): void
+    {
+        //add extra "virtualmachines/vm_plugin_node" as string
+        $extra_sub_prop = ['virtualmachines' => ['vm_plugin_node' => ['type' => 'string']]];
+        $json = json_decode(json_encode([
+            'deviceid' => 'myid',
+            'content' => [
+                'versionclient' => 'GLPI-Agent_v1.0',
+                'virtualmachines' => [
+                    [
+                        'name' => 'My VM',
+                        'vmtype' => 'libvirt',
+                        'vm_plugin_node' => 'plugin node'
+                    ]
+                ]
+            ]
+        ]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraSubProperties($extra_sub_prop));
+        $this->assertTrue($instance->validate($json));
+    }
+
+    public function testValidateAlreadyExistingExtraNode(): void
+    {
+        //try add extra node already existing
+        $extra_prop = ['accesslog' => ['type' => 'string']];
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0']]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraProperties($extra_prop));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Property accesslog already exists in schema.');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateUAlreadyExistingExtraSubNode(): void
+    {
+        //try add extra sub node already existing
+        $extra_sub_prop = ['hardware' => ['chassis_type' => ['type' => 'string']]];
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0']]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraSubProperties($extra_sub_prop));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Property hardware/chassis_type already exists in schema.');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testValidateMissingParentSubNode(): void
+    {
+        //try add extra sub node with missing parent
+        $extra_sub_prop = ['unknown' => ['chassis_type' => ['type' => 'string']]];
+        $json = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0']]));
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertInstanceOf(\Glpi\Inventory\Schema::class, $instance->setExtraSubProperties($extra_sub_prop));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Property unknown does not exists in schema.');
+        $this->assertFalse($instance->validate($json));
+    }
+
+    public function testFlexibleSchema(): void
+    {
+        $json_additionnal = json_decode(json_encode(['deviceid' => 'myid', 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'additional' => ['name' => 'my extra data']]]));
+        $instance = new \Glpi\Inventory\Schema();
+        $instance->setFlexible();
+        $this->assertTrue($instance->validate($json_additionnal));
+
+        //tests same JSON fails with strict schema
+        $instance->setStrict();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Additional properties not allowed: additional');
+        $this->assertTrue($instance->validate($json_additionnal));
+    }
+}

--- a/tests/Glpi/Inventory/tests/units/Schema.php
+++ b/tests/Glpi/Inventory/tests/units/Schema.php
@@ -186,4 +186,10 @@ class Schema extends TestCase
         $this->expectExceptionMessage('Additional properties not allowed: additional');
         $this->assertTrue($instance->validate($json_additionnal));
     }
+
+    public function testVersion(): void
+    {
+        $instance = new \Glpi\Inventory\Schema();
+        $this->assertIsFloat($instance->getVersion());
+    }
 }


### PR DESCRIPTION
Add method to make schema validation more flexible (allowing additional properties in content and all child nodes). This is the first commit.

Also:
- create a Schema class instead of doing everything in Converter
- use Schema version (bumped to 1.0) from schema file instead of duplicating in PHP class

Can be reviewed per commit