### PR TITLE
Fix deprecation warning on PHP 8.4

### DIFF
--- a/lib/php/FilesToJSON.php
+++ b/lib/php/FilesToJSON.php
@@ -260,7 +260,7 @@ final class FilesToJSON
         $iftypeFile = $this->getSourceFile(self::TYPE_IFTYPE);
         $iftypes = [];
 
-        while ($line = fgetcsv($iftypeFile)) {
+        while ($line = fgetcsv($iftypeFile, 0, ',', '"', '')) {
             $iftypes[] = [
                 'decimal'     => $line[0],
                 'name'        => $line[1],


### PR DESCRIPTION
Fixes the following error:
```
Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /var/www/glpi/vendor/glpi-project/inventory_format/lib/php/FilesToJSON.php on line 263

Call Stack:
    0.0003     412896   1. {main}() /var/www/glpi/vendor/bin/build_hw_jsons:0
    0.0004     414584   2. include('/var/www/glpi/vendor/glpi-project/inventory_format/bin/build_hw_jsons') /var/www/glpi/vendor/bin/build_hw_jsons:119
    0.0232    5683296   3. Glpi\Inventory\FilesToJSON->run() /var/www/glpi/vendor/glpi-project/inventory_format/bin/build_hw_jsons:14
    0.3098    5683416   4. Glpi\Inventory\FilesToJSON->convertIftypeFile() /var/www/glpi/vendor/glpi-project/inventory_format/lib/php/FilesToJSON.php:82
    0.3147    5871752   5. fgetcsv($stream = resource(72) of type (stream)) /var/www/glpi/vendor/glpi-project/inventory_format/lib/php/FilesToJSON.php:263
```

See https://php.watch/versions/8.4/csv-functions-escape-parameter