### PR TITLE
Feat(Format): handle PDU

### DIFF
--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2838,7 +2838,7 @@
             },
             "type": {
               "type": "string",
-              "pattern": "^(Unmanaged|Computer|Networking|Printer|Storage|Power|Phone|Video|KVM)$"
+              "pattern": "^(Unmanaged|Computer|Networking|Printer|Storage|Power|Phone|Video|KVM|Pdu)$"
             },
             "uptime": {
               "type": "string",
@@ -2850,6 +2850,33 @@
                 "Cisco"
               ]
             },
+          "pdu": {
+            "type": "object",
+            "title": "Power Distribution Unit inventory",
+            "properties": {
+              "type": {
+                "type": "string",
+                "title": "PDU type"
+              },
+              "plugs": {
+                "title": "List of plugs of pdu",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
             "contact": {
               "type": "string"
             },
@@ -2967,7 +2994,7 @@
       "type": "string",
       "title": "Item type",
       "default": "Unmanaged",
-      "pattern": "^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$"
+      "pattern": "^(Unmanaged|Computer|Phone|NetworkEquipment|Printer|Pdu)$"
     },
     "partial": {
       "type": "boolean",

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2850,33 +2850,6 @@
                 "Cisco"
               ]
             },
-            "pdu": {
-              "type": "object",
-              "title": "Power Distribution Unit inventory",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "title": "PDU type"
-                },
-                "plugs": {
-                  "title": "List of plugs of pdu",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
             "contact": {
               "type": "string"
             },
@@ -2884,6 +2857,33 @@
               "type": "integer"
             }
           }
+        },
+        "pdu": {
+          "type": "object",
+          "title": "Power Distribution Unit inventory",
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "PDU type"
+            },
+            "plugs": {
+              "title": "List of plugs of pdu",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         },
         "databases_services": {
           "type": "array",

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2876,7 +2876,16 @@
                 ],
                 "properties": {
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "title": "Plug name"
+                  },
+                  "number": {
+                    "type": "string",
+                    "title": "Plug number"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Plug type"
                   }
                 }
               },

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2850,33 +2850,33 @@
                 "Cisco"
               ]
             },
-          "pdu": {
-            "type": "object",
-            "title": "Power Distribution Unit inventory",
-            "properties": {
-              "type": {
-                "type": "string",
-                "title": "PDU type"
-              },
-              "plugs": {
-                "title": "List of plugs of pdu",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name"
-                  ],
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+            "pdu": {
+              "type": "object",
+              "title": "Power Distribution Unit inventory",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "PDU type"
                 },
-                "additionalProperties": false
-              }
+                "plugs": {
+                  "title": "List of plugs of pdu",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             },
-            "additionalProperties": false
-          },
             "contact": {
               "type": "string"
             },

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2855,44 +2855,44 @@
             },
             "credentials": {
               "type": "integer"
-            }
-          }
-        },
-        "pdu": {
-          "type": "object",
-          "title": "Power Distribution Unit inventory",
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "PDU type"
             },
-            "plugs": {
-              "title": "List of plugs of pdu",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "title": "Plug name"
+            "pdu": {
+              "type": "object",
+              "title": "Power Distribution Unit inventory",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "PDU type"
+                },
+                "plugs": {
+                  "title": "List of plugs of pdu",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Plug name"
+                      },
+                      "number": {
+                        "type": "integer",
+                        "title": "Plug number"
+                      },
+                      "type": {
+                        "type": "string",
+                        "title": "Plug type"
+                      }
+                    }
                   },
-                  "number": {
-                    "type": "integer",
-                    "title": "Plug number"
-                  },
-                  "type": {
-                    "type": "string",
-                    "title": "Plug type"
-                  }
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false
             }
-          },
-          "additionalProperties": false
+          }
         },
         "databases_services": {
           "type": "array",

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2880,7 +2880,7 @@
                     "title": "Plug name"
                   },
                   "number": {
-                    "type": "string",
+                    "type": "integer",
                     "title": "Plug number"
                   },
                   "type": {

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -352,7 +352,7 @@ class Converter
             'remote_mgmt',
             'cartridges',
             'cameras',
-            'user'
+            'user',
         ];
 
         foreach ($arrays as $array) {
@@ -366,7 +366,7 @@ class Converter
             'versionprovider/comments',
             'cameras/resolution',
             'cameras/imageformats',
-            'cameras/resolutionvideo'
+            'cameras/resolutionvideo',
         ];
 
         foreach ($sub_arrays as $array) {

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1438,9 +1438,10 @@ class Converter
                 case "error":
                     $data['content'][$key] = $device_data;
                     break;
-               case "pdu":
+                case "pdu":
                     // put pdu into network_device
                     $data['content']['network_device'][$key] = $device_data;
+                    break;
                 default:
                     throw new RuntimeException('Key ' . $key . ' is not handled in network devices conversion');
             }

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1303,6 +1303,7 @@ class Converter
                                 case 'Phone':
                                 case 'Printer':
                                 case 'Unmanaged':
+                                case 'Pdu':
                                     $itemtype = $device_info['type'];
                                     break;
                                 case 'Networking':

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1436,9 +1436,11 @@ class Converter
                 case "pagecounters":
                 case "drives":
                 case "error":
-                case "pdu":
                     $data['content'][$key] = $device_data;
                     break;
+               case "pdu":
+                    // put pdu into network_device
+                    $data['content']['network_device'][$key] = $device_data;
                 default:
                     throw new RuntimeException('Key ' . $key . ' is not handled in network devices conversion');
             }

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -1436,6 +1436,7 @@ class Converter
                 case "pagecounters":
                 case "drives":
                 case "error":
+                case "pdu":
                     $data['content'][$key] = $device_data;
                     break;
                 default:

--- a/lib/php/Converter.php
+++ b/lib/php/Converter.php
@@ -352,7 +352,7 @@ class Converter
             'remote_mgmt',
             'cartridges',
             'cameras',
-            'user',
+            'user'
         ];
 
         foreach ($arrays as $array) {
@@ -366,7 +366,7 @@ class Converter
             'versionprovider/comments',
             'cameras/resolution',
             'cameras/imageformats',
-            'cameras/resolutionvideo',
+            'cameras/resolutionvideo'
         ];
 
         foreach ($sub_arrays as $array) {

--- a/tests/Glpi/Inventory/tests/units/Schema.php
+++ b/tests/Glpi/Inventory/tests/units/Schema.php
@@ -51,7 +51,7 @@ class Schema extends TestCase
         $json = json_decode(json_encode(['deviceid' => 'myid', 'itemtype' => $itemtype, 'content' => ['versionclient' => 'GLPI-Agent_v1.0', 'hardware' => ['name' => 'my inventory']]]));
         $instance = new \Glpi\Inventory\Schema();
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('\\\\Glpi\\\\Custom\\\\Asset\\\\Mine" does not match to ^(Unmanaged|Computer|Phone|NetworkEquipment|Printer)$');
+        $this->expectExceptionMessage('\\\\Glpi\\\\Custom\\\\Asset\\\\Mine" does not match to ^(Unmanaged|Computer|Phone|NetworkEquipment|Printer|Pdu)$');
         $this->assertFalse($instance->validate($json));
     }
 


### PR DESCRIPTION
Handle `PDU` inventory from SNMP

Needed by : https://github.com/glpi-project/glpi/pull/22863

fixes : https://github.com/glpi-project/Professional-Services/issues/27

Here’s the English summary of this updated **PDU** structure:

* **Main object: `pdu`**

  * **Type:** `object`
  * **Required property:** `name`

#### **Properties:**

1. **`name`**: `string`

   * The name of the PDU.

2. **`model`**: `string`

   * The model of the PDU.

3. **`type`**: `string` (required)

   * The type of PDU.

4. **`credentials`**: `integer`

   * Reference to glpi snmpcredentials_id (optional).

5. **`sysdescr`**: `string`

   * Remote device system description.

6. **`plugs`**: `array` of objects

   * List of the PDU’s plugs.
   * Each plug is an object with:

     * **`name`**: `string` (required) — Name of the plug.
     * **`number`**: `string` (optional) — Plug number.
     * **`type`**: `string` (optional) — Plug type.

