### PR TITLE
add docker files + composer scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG PHP_VERSION=8.3
+FROM php:${PHP_VERSION}-cli
+
+# Install runtime dependencies required by this project.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends expat git unzip libcurl4-openssl-dev libxml2-dev \
+    && docker-php-ext-install curl simplexml \
+    && rm -rf /var/lib/apt/lists/*
+
+# Reuse Composer binary from the official image.
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+RUN git config --global --add safe.directory /workdir
+
+WORKDIR /workdir
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,31 @@ It relies on [JSON Schema](https://json-schema.org).
 The [inventory.schema.json](inventory.schema.json) file is the JSON schema itself.
 
 The [lib/php](lib/php) directory contains a PHP class that cans handle conversion from XML files to new format; with some adjustments. You can either use directly ``Convert`` from your project, or rely on the [executable script](bin/convert) provided.
+
+## Run unit tests 
+
+You can use the local PHP environment or the provided Docker image to run unit tests.
+
+### Localhost
+
+```sh
+composer test
+```
+### With Docker Compose
+
+```sh
+docker compose run --rm ci
+```
+
+To use another PHP version:
+
+```sh
+PHP_VERSION=7.4 docker compose run --rm --build ci
+```
+
+PHP_VERSION can be set from 7.4 to 8.5 (default is 8.3).
+
+In case, you need a shell in the container to run some tests manually:
+
+```sh
+docker compose run --rm ci bash

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,26 @@
         "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "^4.0"
     },
+    "scripts": {
+        "build-hardware-jsons": "bin/build_hw_jsons && rm data/*.json && echo 'Hardware JSONs built and moved to data/'",
+        "schema-lint": "vendor/bin/jsonlint inventory.schema.json",
+        "xml-well-formed": "xmlwf tests/data/*.xml && echo 'All XML files are well-formed'",
+        "psr12": "vendor/bin/phpcs --standard=PSR12 lib/php/* && echo 'PSR-12 check passed'",
+        "static-analysis": "vendor/bin/phpstan analyze  --memory-limit 512M --ansi --no-interaction --no-progress && echo 'Static analysis passed'",
+        "conversions-test": "for i in tests/data/*.xml; do ./bin/convert $i || exit 1; done && echo 'All conversions passed'",
+        "examples-validation": "for i in examples/*.json; do ./bin/validate $i || exit 1; done && echo 'All example JSON files are valid'",
+        "unit-tests": "vendor/bin/phpunit --process-isolation --test-suffix=.php --bootstrap tests/bootstrap.php tests/Glpi",
+        "ci": [
+            "@build-hardware-jsons",
+            "@schema-lint",
+            "@xml-well-formed",
+            "@psr12",
+            "@static-analysis",
+            "@conversions-test",
+            "@examples-validation",
+            "@unit-tests"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        PHP_VERSION: ${PHP_VERSION}
+        PHP_VERSION: ${PHP_VERSION:-8.3}
     working_dir: /workdir
     volumes:
       - .:/workdir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  ci:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PHP_VERSION: ${PHP_VERSION}
+    working_dir: /workdir
+    volumes:
+      - .:/workdir
+      - composer_cache:/tmp/composer-cache
+    environment:
+      COMPOSER_CACHE_DIR: /tmp/composer-cache
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        git config --global --add safe.directory /workdir
+        composer install --no-progress --no-interaction --ignore-platform-req=php+
+        php --version
+        composer ci
+
+volumes:
+  composer_cache:


### PR DESCRIPTION
+ easier testing with different php versions
+ simple command to run all the ci in one command `composer run-script ci` (which can run with both local php and docker).

Also note that, in the future, all the ci steps related to testing can be replaced by the same command `composer run-script ci`. Not for the moment.