### PR TITLE
feat: add drives and networks as optional fields inside virtualmachines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The present file will list all changes made to the project; according to the
 
 ## [Unreleased]
 
-Add storages support in virtual machines
+Add drives support in virtual machines
 
 ## [1.2.4] - UNRELEASED
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,11 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
-## [Unreleased]
-
-Add drives support in virtual machines
-
 ## [1.2.4] - UNRELEASED
 
 Add network traffic statistics to NETWORKS node
+
+Add drives support in virtual machines
 
 ## [1.2.3] - 2026-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
+## [Unreleased]
+
+Add storages support in virtual machines
+
 ## [1.2.4] - UNRELEASED
 
 Add network traffic statistics to NETWORKS node

--- a/examples/computer_2_partial_vms.json
+++ b/examples/computer_2_partial_vms.json
@@ -63,11 +63,18 @@
                 "vmtype": "docker"
             },
             {
-                "name": "'T",
-                "owner": "local",
-                "subsystem": "Oracle VM VirtualBox",
-                "vcpu": 1,
-                "vmtype": "virtualbox"
+                "name": "ServerVM01",
+                "subsystem": "microsoft",
+                "vcpu": 4,
+                "memory": 8192,
+                "status": "running",
+                "vmtype": "hyperv",
+                "storages": [
+                    {
+                        "name": "C:\\VMs\\ServerVM01.vhdx",
+                        "disksize": 102400
+                    }
+                ]
             }
         ]
     },

--- a/examples/computer_2_partial_vms.json
+++ b/examples/computer_2_partial_vms.json
@@ -63,18 +63,11 @@
                 "vmtype": "docker"
             },
             {
-                "name": "ServerVM01",
-                "subsystem": "microsoft",
-                "vcpu": 4,
-                "memory": 8192,
-                "status": "running",
-                "vmtype": "hyperv",
-                "storages": [
-                    {
-                        "name": "C:\\VMs\\ServerVM01.vhdx",
-                        "disksize": 102400
-                    }
-                ]
+                "name": "'T",
+                "owner": "local",
+                "subsystem": "Oracle VM VirtualBox",
+                "vcpu": 1,
+                "vmtype": "virtualbox"
             }
         ]
     },

--- a/examples/computer_3_partial_hyperv_vms.json
+++ b/examples/computer_3_partial_hyperv_vms.json
@@ -16,14 +16,14 @@
                 "vcpu": 4,
                 "memory": 8192,
                 "vmtype": "hyperv",
-                "storages": [
+                "drives": [
                     {
-                        "name": "C:\\VMs\\ServerVM01.vhdx",
-                        "disksize": 102400
+                        "volumn": "C:\\VMs\\ServerVM01.vhdx",
+                        "total": 102400
                     },
                     {
-                        "name": "\\\\nas01\\VMs\\ServerVM01-data.vhdx",
-                        "disksize": 512000
+                        "volumn": "\\\\nas01\\VMs\\ServerVM01-data.vhdx",
+                        "total": 512000
                     }
                 ]
             },
@@ -34,10 +34,10 @@
                 "vcpu": 2,
                 "memory": 4096,
                 "vmtype": "hyperv",
-                "storages": [
+                "drives": [
                     {
-                        "name": "C:\\VMs\\ServerVM02.vhdx",
-                        "disksize": 51200
+                        "volumn": "C:\\VMs\\ServerVM02.vhdx",
+                        "total": 51200
                     }
                 ]
             }

--- a/examples/computer_3_partial_hyperv_vms.json
+++ b/examples/computer_3_partial_hyperv_vms.json
@@ -1,0 +1,50 @@
+{
+    "content": {
+        "hardware": {
+            "chassis_type": "Server",
+            "memory": 65536,
+            "name": "HYPERV-HOST01",
+            "uuid": "A1B2C3D4-1234-5678-ABCD-1234567890AB",
+            "vmsystem": "Physical"
+        },
+        "versionclient": "GLPI-Agent_v1.12",
+        "virtualmachines": [
+            {
+                "name": "ServerVM01",
+                "status": "running",
+                "uuid": "6A257FA0-FA76-4BF4-A3FB-67AEE79316BD",
+                "vcpu": 4,
+                "memory": 8192,
+                "vmtype": "hyperv",
+                "storages": [
+                    {
+                        "name": "C:\\VMs\\ServerVM01.vhdx",
+                        "disksize": 102400
+                    },
+                    {
+                        "name": "\\\\nas01\\VMs\\ServerVM01-data.vhdx",
+                        "disksize": 512000
+                    }
+                ]
+            },
+            {
+                "name": "ServerVM02",
+                "status": "off",
+                "uuid": "7B368GB1-GB87-5CG5-B4GC-78BFF8A427CE",
+                "vcpu": 2,
+                "memory": 4096,
+                "vmtype": "hyperv",
+                "storages": [
+                    {
+                        "name": "C:\\VMs\\ServerVM02.vhdx",
+                        "disksize": 51200
+                    }
+                ]
+            }
+        ]
+    },
+    "deviceid": "hyperv-host-2024-01-15-10-00-00",
+    "action": "inventory",
+    "itemtype": "Computer",
+    "partial": true
+}

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2108,6 +2108,9 @@
               },
               "serial": {
                 "type": "string"
+              },
+              "storages": {
+                "$ref": "#/properties/content/properties/storages"
               }
             }
           }

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2109,8 +2109,8 @@
               "serial": {
                 "type": "string"
               },
-              "storages": {
-                "$ref": "#/properties/content/properties/storages"
+              "drives": {
+                "$ref": "#/properties/content/properties/drives"
               }
             }
           }

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -2111,6 +2111,27 @@
               },
               "drives": {
                 "$ref": "#/properties/content/properties/drives"
+              },
+              "networks": {
+                "type": "array",
+                "title": "Virtual machine network adapters",
+                "items": {
+                  "type": "object",
+                  "required": ["description"],
+                  "properties": {
+                    "description": {
+                      "type": "string",
+                      "title": "Network adapter name as reported by the hypervisor",
+                      "examples": ["Network Adapter", "Network Adapter 2"]
+                    },
+                    "macaddr": {
+                      "type": "string",
+                      "title": "MAC address in canonical lowercase format (xx:xx:xx:xx:xx:xx)",
+                      "examples": ["00:11:22:aa:bb:cc"],
+                      "pattern": "^([0-9a-f]{2}:){5}[0-9a-f]{2}$"
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Add `drives` and `networks` as optional fields inside `virtualmachines`. This allows hypervisors such as Hyper-V to report virtual disk files (VHDs) and network adapters per VM.

## Changes

- `inventory.schema.json`: add `drives` (via `$ref`) and `networks` (inline definition) as optional fields in `virtualmachines`
- `examples/computer_3_partial_hyperv_vms.json`: Hyper-V VM example with `drives` entries
- `CHANGELOG.md`: unreleased entry

## Notes

- Non-breaking change: both fields are optional, existing inventories are unaffected
- `drives`: agents send `volumn` (VHD path) and `total` (size in MB)
- `networks`: agents send `description` (adapter name) and `macaddr` (MAC in canonical lowercase format)
- No changes needed on the GLPI core side: `VirtualMachine.php` already handles both fields
- Related to [glpi-project/glpi-agent#1163](https://github.com/glpi-project/glpi-agent/pull/1163)
