### PR TITLE
feat(schema): add network traffic statistics to NETWORKS node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
-## [1.2.4] - 2026-08-03
+## [1.2.4] - UNRELEASED
 
 Add network traffic statistics to NETWORKS node
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The present file will list all changes made to the project; according to the
 [Keep a Changelog](http://keepachangelog.com/) project.
 
+## [1.2.4] - 2026-08-03
+
+Add network traffic statistics to NETWORKS node
+
 ## [1.2.3] - 2026-01-22
 
 Exclude CSV header from iftypes conversion

--- a/inventory.schema.json
+++ b/inventory.schema.json
@@ -1305,6 +1305,22 @@
               },
               "wifi_version": {
                 "type": "string"
+              },
+              "ifinbytes": {
+                "type": "integer",
+                "title": "Number of input bytes"
+              },
+              "ifoutbytes": {
+                "type": "integer",
+                "title": "Number of output bytes"
+              },
+              "ifinerrors": {
+                "type": "integer",
+                "title": "Number of input errors"
+              },
+              "ifouterrors": {
+                "type": "integer",
+                "title": "Number of output errors"
               }
             }
           }


### PR DESCRIPTION
# Description
This PR updates the `inventory.schema.json` to natively support network traffic statistics on computer network interfaces (the `networks` node) as suggested in https://github.com/glpi-project/glpi-agent/pull/1184. 
Previously, extracting metrics like bytes and errors was restricted to the `network_ports` node, which is primarily intended for networking equipment and not suitable for standard computer inventory flows.
### Changes:
- Added `ifinbytes` (Number of input bytes)
- Added `ifoutbytes` (Number of output bytes)
- Added `ifinerrors` (Number of input errors)
- Added `ifouterrors` (Number of output errors)
This schema change serves as the foundation for collecting Windows and Linux interface performance metrics natively under computer assets without overlapping with `network_ports`.
